### PR TITLE
[#2] 회원 Entity 제작 및 회원 가입 기능 구현

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/user-service/src/main/java/me/kong/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/me/kong/userservice/UserServiceApplication.java
@@ -2,7 +2,9 @@ package me.kong.userservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class UserServiceApplication {
 

--- a/user-service/src/main/java/me/kong/userservice/common/HttpStatusResponseEntity.java
+++ b/user-service/src/main/java/me/kong/userservice/common/HttpStatusResponseEntity.java
@@ -1,0 +1,8 @@
+package me.kong.userservice.common;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class HttpStatusResponseEntity {
+    public static final ResponseEntity<HttpStatus> RESPONSE_OK =ResponseEntity.status(HttpStatus.OK).build();
+}

--- a/user-service/src/main/java/me/kong/userservice/common/config/SecurityConfig.java
+++ b/user-service/src/main/java/me/kong/userservice/common/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package me.kong.userservice.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/user-service/src/main/java/me/kong/userservice/common/exception/DuplicateElementException.java
+++ b/user-service/src/main/java/me/kong/userservice/common/exception/DuplicateElementException.java
@@ -1,0 +1,11 @@
+package me.kong.userservice.common.exception;
+
+public class DuplicateElementException extends RuntimeException {
+    public DuplicateElementException() {
+        super();
+    }
+
+    public DuplicateElementException(String message) {
+        super(message);
+    }
+}

--- a/user-service/src/main/java/me/kong/userservice/common/exception/ErrorInfo.java
+++ b/user-service/src/main/java/me/kong/userservice/common/exception/ErrorInfo.java
@@ -1,0 +1,21 @@
+package me.kong.userservice.common.exception;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ErrorInfo {
+    private String errorType;
+    private String msg;
+
+    public ErrorInfo(String errorType, String msg) {
+        this.errorType = errorType;
+        this.msg = msg;
+    }
+
+    public ErrorInfo(Throwable e) {
+        this.errorType = e.getClass().getSimpleName();
+        this.msg = e.getMessage();
+    }
+}

--- a/user-service/src/main/java/me/kong/userservice/common/exception/advice/ExceptionAdvice.java
+++ b/user-service/src/main/java/me/kong/userservice/common/exception/advice/ExceptionAdvice.java
@@ -1,0 +1,25 @@
+package me.kong.userservice.common.exception.advice;
+
+
+import me.kong.userservice.common.exception.DuplicateElementException;
+import me.kong.userservice.common.exception.ErrorInfo;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ErrorInfo> noSuchElementException(NoSuchElementException e) {
+        return new ResponseEntity<>(new ErrorInfo(e), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(DuplicateElementException.class)
+    public ResponseEntity<ErrorInfo> DuplicateElementException(DuplicateElementException e) {
+        return new ResponseEntity<>(new ErrorInfo(e), HttpStatus.CONFLICT);
+    }
+}

--- a/user-service/src/main/java/me/kong/userservice/controller/UserController.java
+++ b/user-service/src/main/java/me/kong/userservice/controller/UserController.java
@@ -1,0 +1,40 @@
+package me.kong.userservice.controller;
+
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import me.kong.userservice.controller.dto.UserRegisterRequestDto;
+import me.kong.userservice.controller.dto.UserResponseDto;
+import me.kong.userservice.domain.entity.user.User;
+import me.kong.userservice.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static me.kong.userservice.common.HttpStatusResponseEntity.RESPONSE_OK;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<HttpStatus> register(@RequestBody @Valid UserRegisterRequestDto dto) {
+        userService.addNewUser(dto);
+        return RESPONSE_OK;
+    }
+
+    @GetMapping("/{email}/exists")
+    public ResponseEntity<HttpStatus> checkUniqueEmail(@PathVariable String email) {
+        userService.checkUniqueEmail(email);
+        return RESPONSE_OK;
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserResponseDto> getUserInfo(@PathVariable Long userId) {
+        User user = userService.findUserById(userId);
+
+        return ResponseEntity.ok(UserResponseDto.of(user));
+    }
+}

--- a/user-service/src/main/java/me/kong/userservice/controller/dto/UserRegisterRequestDto.java
+++ b/user-service/src/main/java/me/kong/userservice/controller/dto/UserRegisterRequestDto.java
@@ -1,0 +1,34 @@
+package me.kong.userservice.controller.dto;
+
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import me.kong.userservice.domain.entity.user.User;
+
+@Getter
+@Builder
+public class UserRegisterRequestDto {
+    @NotEmpty
+    @Email(message = "유효하지 않은 이메일 형식입니다.")
+    private String email;
+
+    @NotEmpty
+    private String password;
+
+    @NotEmpty
+    private String name;
+
+    @NotEmpty
+    private String nickname;
+
+    public User toEntity(String encryptedPassword) {
+        return User.builder()
+                .email(email)
+                .password(encryptedPassword)
+                .name(name)
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/user-service/src/main/java/me/kong/userservice/controller/dto/UserResponseDto.java
+++ b/user-service/src/main/java/me/kong/userservice/controller/dto/UserResponseDto.java
@@ -1,0 +1,26 @@
+package me.kong.userservice.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import me.kong.userservice.domain.entity.user.Role;
+import me.kong.userservice.domain.entity.user.User;
+
+@Getter
+@Builder
+public class UserResponseDto {
+    private Long userId;
+    private String email;
+    private String name;
+    private String nickname;
+    private Role role;
+
+    public static UserResponseDto of(User user) {
+        return UserResponseDto.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .nickname(user.getNickname())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/user-service/src/main/java/me/kong/userservice/domain/BaseTimeEntity.java
+++ b/user-service/src/main/java/me/kong/userservice/domain/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package me.kong.userservice.domain;
+
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime updatedDate;
+}

--- a/user-service/src/main/java/me/kong/userservice/domain/entity/user/Role.java
+++ b/user-service/src/main/java/me/kong/userservice/domain/entity/user/Role.java
@@ -1,0 +1,6 @@
+package me.kong.userservice.domain.entity.user;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/user-service/src/main/java/me/kong/userservice/domain/entity/user/User.java
+++ b/user-service/src/main/java/me/kong/userservice/domain/entity/user/User.java
@@ -1,0 +1,43 @@
+package me.kong.userservice.domain.entity.user;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.kong.userservice.domain.BaseTimeEntity;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "users")
+public class User extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    private String password;
+
+    private String name;
+
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_role", nullable = false)
+    private Role role;
+
+    @Builder
+    public User(String email, String password, String name, String nickname) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.nickname = nickname;
+    }
+
+    public void updateRole(Role role) {
+        this.role = role;
+    }
+}

--- a/user-service/src/main/java/me/kong/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/me/kong/userservice/domain/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package me.kong.userservice.domain.repository;
+
+import me.kong.userservice.domain.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsUserByEmail(String email);
+}

--- a/user-service/src/main/java/me/kong/userservice/service/UserService.java
+++ b/user-service/src/main/java/me/kong/userservice/service/UserService.java
@@ -1,0 +1,47 @@
+package me.kong.userservice.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.kong.userservice.common.exception.DuplicateElementException;
+import me.kong.userservice.controller.dto.UserRegisterRequestDto;
+import me.kong.userservice.domain.entity.user.Role;
+import me.kong.userservice.domain.entity.user.User;
+import me.kong.userservice.domain.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void addNewUser(UserRegisterRequestDto dto) {
+        checkUniqueEmail(dto.getEmail());
+        User user = dto.toEntity(passwordEncoder.encode(dto.getPassword()));
+        user.updateRole(Role.USER);
+        userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public void checkUniqueEmail(String email) {
+        boolean isExist = userRepository.existsUserByEmail(email);
+//        log.info("input email : {}", email);
+        if (isExist) {
+            throw new DuplicateElementException("중복된 이메일입니다. email : " + email);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public User findUserById(Long id) {
+        return userRepository.findById(id).orElseThrow(() -> new NoSuchElementException("찾으려는 사용자가 없습니다. id : " + id));
+    }
+}

--- a/user-service/src/test/java/me/kong/userservice/service/UserServiceTest.java
+++ b/user-service/src/test/java/me/kong/userservice/service/UserServiceTest.java
@@ -1,0 +1,115 @@
+package me.kong.userservice.service;
+
+import me.kong.userservice.common.exception.DuplicateElementException;
+import me.kong.userservice.controller.dto.UserRegisterRequestDto;
+import me.kong.userservice.domain.entity.user.User;
+import me.kong.userservice.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @InjectMocks
+    UserService userService;
+
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    UserRegisterRequestDto registerRequestDto;
+
+    @BeforeEach
+    void init() {
+        registerRequestDto = UserRegisterRequestDto.builder()
+                .email("email@email.com")
+                .password("password")
+                .name("test")
+                .nickname("test nickname")
+                .build();
+    }
+
+    @Test
+    @DisplayName("중복된 이메일로 회원 가입 시 DuplicateElementException을 발생시킨다")
+    void saveMemberWithDuplicatedEmail() {
+        //given
+        when(userRepository.existsUserByEmail(any())).thenReturn(true);
+
+        //then
+        assertThrows(DuplicateElementException.class, () -> userService.addNewUser(registerRequestDto));
+    }
+
+    @Test
+    @DisplayName("중복되지 않은 이메일로 회원 가입 시, 사용자를 저장한다.")
+    void saveMember() {
+        //given
+        when(userRepository.existsUserByEmail(any())).thenReturn(false);
+
+        //when
+        userService.addNewUser(registerRequestDto);
+
+        //then
+        verify(passwordEncoder, times(1)).encode(registerRequestDto.getPassword());
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("이메일이 중복되었을 경우, DuplicateElementException을 발생시킨다")
+    void isDuplicatedEmailExist() {
+        //given
+        when(userRepository.existsUserByEmail(any())).thenReturn(true);
+
+        //then
+        assertThrows(DuplicateElementException.class, () -> userService.checkUniqueEmail(any()));
+    }
+
+    @Test
+    @DisplayName("이메일이 중복되지 않았을경우, 정상적으로 진행한다")
+    void isNotDuplicatedEmailExist() {
+        //given
+        when(userRepository.existsUserByEmail(any())).thenReturn(false);
+
+        //when
+        userService.checkUniqueEmail(any());
+
+        //then
+        verify(userRepository, times(1)).existsUserByEmail(any());
+    }
+
+    @Test
+    @DisplayName("찾으려는 사용자가 존재하지 않을 경우 NoSuchElementException을 발생시킨다")
+    void isNotExistUserFindById() {
+        //given
+        when(userRepository.findById(any())).thenReturn(Optional.empty());
+
+        //then
+        assertThrows(NoSuchElementException.class, () -> userService.findUserById(any()));
+    }
+
+    @Test
+    @DisplayName("사용자 조회에 성공했을 경우, 해당 사용자를 반환한다.")
+    void isExistUserFindById() {
+        //given
+        User user = mock();
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
+
+        //when
+        User findUser = userService.findUserById(any());
+
+        //then
+        assertEquals(user, findUser);
+    }
+}

--- a/user-service/src/test/java/me/kong/userservice/service/UserValidationTest.java
+++ b/user-service/src/test/java/me/kong/userservice/service/UserValidationTest.java
@@ -1,0 +1,68 @@
+package me.kong.userservice.service;
+
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import me.kong.userservice.controller.dto.UserRegisterRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class UserValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void init() {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @Test
+    @DisplayName("회원 가입 시, 모두 정상적으로 입력할 경우 validation을 통과한다")
+    void registerSuccess() {
+        UserRegisterRequestDto registerDto = UserRegisterRequestDto.builder()
+                .email("test@test.com")
+                .password("password")
+                .name("testuser")
+                .nickname("nickname")
+                .build();
+
+        Set<ConstraintViolation<UserRegisterRequestDto>> validate = validator.validate(registerDto);
+        assertThat(validate).isEmpty();
+    }
+
+    @Test
+    @DisplayName("회원 가입 시, 잘못된 이메일 형식일 경우 validation에 실패한다")
+    void registerFailedByEmailFormat() {
+        UserRegisterRequestDto registerDto = UserRegisterRequestDto.builder()
+                .email("test#test.com")
+                .password("password")
+                .name("testuser")
+                .nickname("nickname")
+                .build();
+
+        Set<ConstraintViolation<UserRegisterRequestDto>> validate = validator.validate(registerDto);
+        assertThat(validate.iterator().next().getMessage()).isEqualTo("유효하지 않은 이메일 형식입니다.");
+    }
+
+    @Test
+    @DisplayName("회원 가입 시, NotEmpty 속성이 비어있을 경우 validation에 실패한다")
+    void registerFailedByEmptyField() {
+        UserRegisterRequestDto registerDto = UserRegisterRequestDto.builder()
+                .email("test@test.com")
+                .password("")
+                .name("")
+                .nickname("")
+                .build();
+
+        Set<ConstraintViolation<UserRegisterRequestDto>> validate = validator.validate(registerDto);
+        assertThat(validate.size()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
## 구현 기능
- 회원 가입
- 이메일 중복 체크
- 회원 정보 조회

## 개발 코멘트
- Entity <-> dto 사이의 변환은 dto가 담당합니다.
-> 회원 관리와 인증을 담당할 마이크로서비스이기에 확장이 덜 발생한다고 생각, 비교적 간단한 구조로 진행했습니다.