### PR TITLE
[#6] 그룹 생성 API 구현

### DIFF
--- a/group-service/build.gradle
+++ b/group-service/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/group-service/src/main/java/me/kong/groupservice/GroupServiceApplication.java
+++ b/group-service/src/main/java/me/kong/groupservice/GroupServiceApplication.java
@@ -2,7 +2,10 @@ package me.kong.groupservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+
+@EnableJpaAuditing
 @SpringBootApplication
 public class GroupServiceApplication {
 

--- a/group-service/src/main/java/me/kong/groupservice/common/JwtReader.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/JwtReader.java
@@ -1,0 +1,13 @@
+package me.kong.groupservice.common;
+
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtReader {
+
+    // 인증 기능이 구현되지 않아 임의의 값을 반환
+    public Long getUserId() {
+        return 1L;
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
@@ -1,0 +1,29 @@
+package me.kong.groupservice.controller;
+
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.dto.request.SaveGroupRequestDto;
+import me.kong.groupservice.dto.response.GroupResponseDto;
+import me.kong.groupservice.mapper.GroupMapper;
+import me.kong.groupservice.service.GroupService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/groups")
+@RequiredArgsConstructor
+public class GroupController {
+
+    private final GroupService groupService;
+
+    private final GroupMapper groupMapper;
+
+    @PostMapping
+    public ResponseEntity<GroupResponseDto> addGroup(@RequestBody @Valid SaveGroupRequestDto dto) {
+        Group group = groupService.createNewGroup(dto);
+
+        return ResponseEntity.ok(groupMapper.toDto(group));
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/BaseTimeEntity.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package me.kong.groupservice.domain.entity;
+
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime updatedDate;
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/State.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/State.java
@@ -1,0 +1,7 @@
+package me.kong.groupservice.domain.entity;
+
+public enum State {
+    GENERAL,
+    DELETED,
+    RESTRICTED
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/group/Group.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/group/Group.java
@@ -1,0 +1,49 @@
+package me.kong.groupservice.domain.entity.group;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.kong.groupservice.domain.entity.BaseTimeEntity;
+import me.kong.groupservice.domain.entity.profile.Profile;
+import me.kong.groupservice.domain.entity.State;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "groups")
+public class Group extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    @Column(name = "join_condition")
+    @Enumerated(EnumType.STRING)
+    private JoinCondition joinCondition;
+
+    @Column(name = "group_scope")
+    @Enumerated(EnumType.STRING)
+    private GroupScope groupScope;
+
+    @Enumerated(EnumType.STRING)
+    private State state;
+
+    @OneToMany(mappedBy = "group", fetch = FetchType.LAZY)
+    private List<Profile> profiles;
+
+    @Builder
+    public Group(String name, String description, JoinCondition joinCondition, GroupScope groupScope, State state) {
+        this.name = name;
+        this.description = description;
+        this.joinCondition = joinCondition;
+        this.groupScope = groupScope;
+        this.state = state;
+    }
+
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/group/GroupScope.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/group/GroupScope.java
@@ -1,0 +1,6 @@
+package me.kong.groupservice.domain.entity.group;
+
+public enum GroupScope {
+    PUBLIC,
+    PRIVATE
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/group/JoinCondition.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/group/JoinCondition.java
@@ -1,0 +1,6 @@
+package me.kong.groupservice.domain.entity.group;
+
+public enum JoinCondition {
+    OPEN,
+    APPROVAL_REQUIRED
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/profile/GroupRole.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/profile/GroupRole.java
@@ -1,0 +1,7 @@
+package me.kong.groupservice.domain.entity.profile;
+
+public enum GroupRole {
+    MASTER,
+    MANAGER,
+    MEMBER
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/profile/Profile.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/profile/Profile.java
@@ -1,0 +1,44 @@
+package me.kong.groupservice.domain.entity.profile;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.Group;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Profile {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nickname;
+
+    @Column(name = "group_role")
+    @Enumerated(EnumType.STRING)
+    private GroupRole groupRole;
+
+    @Enumerated(EnumType.STRING)
+    private State state;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @Builder
+    public Profile(String nickname, GroupRole groupRole, State state, Long userId, Group group) {
+        this.nickname = nickname;
+        this.groupRole = groupRole;
+        this.state = state;
+        this.userId = userId;
+        this.group = group;
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/GroupRepository.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/GroupRepository.java
@@ -1,0 +1,9 @@
+package me.kong.groupservice.domain.repository;
+
+import me.kong.groupservice.domain.entity.group.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/ProfileRepository.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/ProfileRepository.java
@@ -1,0 +1,7 @@
+package me.kong.groupservice.domain.repository;
+
+import me.kong.groupservice.domain.entity.profile.Profile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProfileRepository extends JpaRepository<Profile, Long> {
+}

--- a/group-service/src/main/java/me/kong/groupservice/dto/request/SaveGroupRequestDto.java
+++ b/group-service/src/main/java/me/kong/groupservice/dto/request/SaveGroupRequestDto.java
@@ -1,0 +1,27 @@
+package me.kong.groupservice.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import me.kong.groupservice.domain.entity.group.GroupScope;
+import me.kong.groupservice.domain.entity.group.JoinCondition;
+
+@Getter
+@Builder
+public class SaveGroupRequestDto {
+
+    @NotEmpty
+    private String groupName;
+
+    private String description;
+
+    @NotNull
+    private GroupScope groupScope;
+
+    @NotNull
+    private JoinCondition joinCondition;
+
+    @NotEmpty
+    private String nickname;
+}

--- a/group-service/src/main/java/me/kong/groupservice/dto/response/GroupResponseDto.java
+++ b/group-service/src/main/java/me/kong/groupservice/dto/response/GroupResponseDto.java
@@ -1,0 +1,12 @@
+package me.kong.groupservice.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GroupResponseDto {
+    private Long id;
+    private String name;
+    private String description;
+}

--- a/group-service/src/main/java/me/kong/groupservice/mapper/GroupMapper.java
+++ b/group-service/src/main/java/me/kong/groupservice/mapper/GroupMapper.java
@@ -1,0 +1,30 @@
+package me.kong.groupservice.mapper;
+
+
+import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.dto.request.SaveGroupRequestDto;
+import me.kong.groupservice.dto.response.GroupResponseDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GroupMapper {
+
+    public Group toEntity(SaveGroupRequestDto dto) {
+        return Group.builder()
+                .name(dto.getGroupName())
+                .description(dto.getDescription())
+                .joinCondition(dto.getJoinCondition())
+                .groupScope(dto.getGroupScope())
+                .state(State.GENERAL)
+                .build();
+    }
+
+     public GroupResponseDto toDto(Group group) {
+        return GroupResponseDto.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .description(group.getDescription())
+                .build();
+     }
+}

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupService.java
@@ -1,0 +1,31 @@
+package me.kong.groupservice.service;
+
+
+import lombok.RequiredArgsConstructor;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.repository.GroupRepository;
+import me.kong.groupservice.dto.request.SaveGroupRequestDto;
+import me.kong.groupservice.mapper.GroupMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GroupService {
+
+    private final GroupRepository groupRepository;
+
+    private final ProfileService profileService;
+
+    private final GroupMapper groupMapper;
+
+    @Transactional
+    public Group createNewGroup(SaveGroupRequestDto dto) {
+        Group group = groupRepository.save(groupMapper.toEntity(dto));
+
+        profileService.createNewProfile(dto.getNickname(), GroupRole.MASTER, group);
+
+        return group;
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
@@ -1,0 +1,32 @@
+package me.kong.groupservice.service;
+
+import lombok.RequiredArgsConstructor;
+import me.kong.groupservice.common.JwtReader;
+import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.profile.Profile;
+import me.kong.groupservice.domain.repository.ProfileRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+
+    private final ProfileRepository profileRepository;
+    private final JwtReader jwtReader;
+
+    @Transactional
+    public void createNewProfile(String nickname, GroupRole groupRole, Group group) {
+        Profile profile = Profile.builder()
+                .nickname(nickname)
+                .groupRole(groupRole)
+                .state(State.GENERAL)
+                .userId(jwtReader.getUserId()) // token에서 현재 로그인한 user의 id를 가져온다.
+                .group(group)
+                .build();
+
+        profileRepository.save(profile);
+    }
+}

--- a/group-service/src/test/java/me/kong/groupservice/integration/GroupManagementServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/integration/GroupManagementServiceTest.java
@@ -1,0 +1,74 @@
+package me.kong.groupservice.integration;
+
+
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.group.GroupScope;
+import me.kong.groupservice.domain.entity.group.JoinCondition;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
+import me.kong.groupservice.domain.repository.GroupRepository;
+import me.kong.groupservice.domain.repository.ProfileRepository;
+import me.kong.groupservice.dto.request.SaveGroupRequestDto;
+import me.kong.groupservice.service.GroupService;
+import me.kong.groupservice.service.ProfileService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+public class GroupManagementServiceTest {
+
+    @Autowired
+    private GroupService groupService;
+
+    @MockBean
+    private ProfileService profileService;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private ProfileRepository profileRepository;
+
+    @BeforeEach
+    void init() {
+        profileRepository.deleteAll();
+        groupRepository.deleteAll();
+    }
+
+
+    @Test
+    @DisplayName("프로필 생성 시 예외가 발생하면 그룹과 프로필 모두 롤백된다")
+    void createGroupTransactionPropagationTest() {
+        //given
+        SaveGroupRequestDto dto = SaveGroupRequestDto.builder()
+                .groupName("테스트 그룹")
+                .description("트랜잭션 전파 동작 테스트용")
+                .groupScope(GroupScope.PUBLIC)
+                .joinCondition(JoinCondition.OPEN)
+                .nickname("testUser")
+                .build();
+
+        doThrow(new RuntimeException())
+                .when(profileService).createNewProfile(anyString(), any(GroupRole.class), any(Group.class));
+
+        //when
+        try {
+            groupService.createNewGroup(dto);
+        } catch (RuntimeException e) {
+            // 예외 발생!!!
+        }
+
+        //then
+        assertTrue(groupRepository.findAll().isEmpty());
+        assertTrue(profileRepository.findAll().isEmpty());
+    }
+}

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupServiceTest.java
@@ -1,0 +1,53 @@
+package me.kong.groupservice.service;
+
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.group.GroupScope;
+import me.kong.groupservice.domain.entity.group.JoinCondition;
+import me.kong.groupservice.domain.repository.GroupRepository;
+import me.kong.groupservice.dto.request.SaveGroupRequestDto;
+import me.kong.groupservice.mapper.GroupMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupServiceTest {
+
+    @InjectMocks
+    GroupService groupService;
+
+    @Mock
+    GroupRepository groupRepository;
+
+    @Mock
+    ProfileService profileService;
+
+    @Mock
+    GroupMapper groupMapper;
+
+
+    @Test
+    @DisplayName("그룹 생성에 성공한다")
+    void successToCreateNewGroup() {
+        //given
+        SaveGroupRequestDto dto = mock();
+        Group group = mock();
+
+        when(groupMapper.toEntity(any(SaveGroupRequestDto.class))).thenReturn(group);
+
+        //when
+        groupService.createNewGroup(dto);
+
+        //then
+        verify(groupRepository, times(1)).save(any(Group.class));
+        verify(groupMapper, times(1)).toEntity(any(SaveGroupRequestDto.class));
+    }
+}

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupValidationTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupValidationTest.java
@@ -1,0 +1,125 @@
+package me.kong.groupservice.service;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import me.kong.groupservice.domain.entity.group.GroupScope;
+import me.kong.groupservice.domain.entity.group.JoinCondition;
+import me.kong.groupservice.dto.request.SaveGroupRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GroupValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void init() {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @Test
+    @DisplayName("그룹 생성 시, 모두 정상적으로 입력됐다면 성공적으로 변환한다.")
+    void successToCreateNewGroup() {
+        SaveGroupRequestDto dto = SaveGroupRequestDto.builder()
+                .groupName("테스트 그룹")
+                .description("테스트용 그룹입니다")
+                .groupScope(GroupScope.PUBLIC)
+                .joinCondition(JoinCondition.OPEN)
+                .nickname("테스트유저123")
+                .build();
+
+        Set<ConstraintViolation<SaveGroupRequestDto>> validate = validator.validate(dto);
+        assertThat(validate).isEmpty();
+    }
+
+    @Test
+    @DisplayName("그룹 생성 시, 그룹 이름이 비어있다면 변환에 실패한다")
+    void failedByEmptyGroupName() {
+        SaveGroupRequestDto dto = SaveGroupRequestDto.builder()
+                .groupName("")
+                .description("테스트용 그룹입니다")
+                .groupScope(GroupScope.PUBLIC)
+                .joinCondition(JoinCondition.OPEN)
+                .nickname("테스트유저123")
+                .build();
+
+        Set<ConstraintViolation<SaveGroupRequestDto>> violations = validator.validate(dto);
+        assertFalse(violations.isEmpty());
+        assertEquals(1, violations.size());
+
+        ConstraintViolation<SaveGroupRequestDto> violation = violations.iterator().next();
+        assertEquals("groupName", violation.getPropertyPath().toString());
+        assertEquals("비어 있을 수 없습니다", violation.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("그룹 생성 시, 닉네임이 비어있다면 변환에 실패한다")
+    void failedByEmptyNickname() {
+        SaveGroupRequestDto dto = SaveGroupRequestDto.builder()
+                .groupName("테스트 그룹")
+                .description("테스트용 그룹입니다")
+                .groupScope(GroupScope.PUBLIC)
+                .joinCondition(JoinCondition.OPEN)
+                .nickname("")
+                .build();
+
+        Set<ConstraintViolation<SaveGroupRequestDto>> violations = validator.validate(dto);
+        assertFalse(violations.isEmpty());
+        assertEquals(1, violations.size());
+
+        ConstraintViolation<SaveGroupRequestDto> violation = violations.iterator().next();
+        assertEquals("nickname", violation.getPropertyPath().toString());
+        assertEquals("비어 있을 수 없습니다", violation.getMessage());
+    }
+
+    @Test
+    @DisplayName("그룹 생성 시, 그룹 범위가 비어있다면 변환에 실패한다")
+    void failedByNullGroupScope() {
+        SaveGroupRequestDto dto = SaveGroupRequestDto.builder()
+                .groupName("테스트 그룹")
+                .description("테스트용 그룹입니다")
+                .groupScope(null)
+                .joinCondition(JoinCondition.OPEN)
+                .nickname("테스트유저123")
+                .build();
+
+        Set<ConstraintViolation<SaveGroupRequestDto>> violations = validator.validate(dto);
+        assertFalse(violations.isEmpty());
+        assertEquals(1, violations.size());
+
+        ConstraintViolation<SaveGroupRequestDto> violation = violations.iterator().next();
+        assertEquals("groupScope", violation.getPropertyPath().toString());
+        assertEquals("널이어서는 안됩니다", violation.getMessage());
+    }
+
+    @Test
+    @DisplayName("그룹 생성 시, 가입 조건이 비어있다면 변환에 실패한다")
+    void failedByNullJoinCondition() {
+        SaveGroupRequestDto dto = SaveGroupRequestDto.builder()
+                .groupName("테스트 그룹")
+                .description("테스트용 그룹입니다")
+                .groupScope(GroupScope.PUBLIC)
+                .joinCondition(null)
+                .nickname("테스트유저123")
+                .build();
+
+        Set<ConstraintViolation<SaveGroupRequestDto>> violations = validator.validate(dto);
+        assertFalse(violations.isEmpty());
+        assertEquals(1, violations.size());
+
+        ConstraintViolation<SaveGroupRequestDto> violation = violations.iterator().next();
+        assertEquals("joinCondition", violation.getPropertyPath().toString());
+        assertEquals("널이어서는 안됩니다", violation.getMessage());
+    }
+
+}

--- a/group-service/src/test/java/me/kong/groupservice/service/ProfileServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/ProfileServiceTest.java
@@ -1,0 +1,48 @@
+package me.kong.groupservice.service;
+
+import me.kong.groupservice.common.JwtReader;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
+import me.kong.groupservice.domain.entity.profile.Profile;
+import me.kong.groupservice.domain.repository.ProfileRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+    @InjectMocks
+    ProfileService profileService;
+
+    @Mock
+    ProfileRepository profileRepository;
+
+    @Mock
+    JwtReader jwtReader;
+
+
+    @Test
+    @DisplayName("프로필 생성에 성공한다")
+    void successToCreateNewProfile() {
+        // Given
+        String nickname = "testUser";
+        GroupRole groupRole = GroupRole.MEMBER;
+        Group group = mock(Group.class);
+        when(jwtReader.getUserId()).thenReturn(1L);
+
+        //when
+        profileService.createNewProfile(nickname, groupRole, group);
+
+        //then
+        verify(jwtReader, times(1)).getUserId();
+        verify(profileRepository, times(1)).save(any(Profile.class));
+    }
+}


### PR DESCRIPTION
## 구현 기능
- 그룹 생성 API에 따른 비즈니스 로직
- 그룹, 프로필 entity 생성

## 개발 코멘트
- 인증 로직이 구현되지 않아 임의의 값을 반환하는 jwtReader 클래스를 작성하여 사용하고 있습니다. 추후 구현 예정입니다.
- user-service와 중복되는 클래스들을 공통 라이브러리로 추출하는 작업을 다음 이슈로 진행할 예정입니다.