### PR TITLE
[#9] 그룹 가입 API 구현

### DIFF
--- a/group-service/src/main/java/me/kong/groupservice/common/exception/DuplicateElementException.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/exception/DuplicateElementException.java
@@ -1,0 +1,11 @@
+package me.kong.groupservice.common.exception;
+
+public class DuplicateElementException extends RuntimeException {
+    public DuplicateElementException() {
+        super();
+    }
+
+    public DuplicateElementException(String message) {
+        super(message);
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/common/exception/ErrorInfo.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/exception/ErrorInfo.java
@@ -1,0 +1,18 @@
+package me.kong.groupservice.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorInfo {
+    private String errorType;
+    private String msg;
+
+    public ErrorInfo(Throwable e) {
+        this.errorType = e.getClass().getSimpleName();
+        this.msg = e.getMessage();
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/common/exception/ForbiddenAccessException.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/exception/ForbiddenAccessException.java
@@ -1,0 +1,11 @@
+package me.kong.groupservice.common.exception;
+
+public class ForbiddenAccessException extends RuntimeException {
+    public ForbiddenAccessException() {
+        super();
+    }
+
+    public ForbiddenAccessException(String message) {
+        super(message);
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/common/exception/NoLoggedInProfileException.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/exception/NoLoggedInProfileException.java
@@ -1,0 +1,7 @@
+package me.kong.groupservice.common.exception;
+
+public class NoLoggedInProfileException extends RuntimeException {
+    public NoLoggedInProfileException() {
+        super();
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/common/exception/advice/GroupExceptionAdvice.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/exception/advice/GroupExceptionAdvice.java
@@ -1,0 +1,40 @@
+package me.kong.groupservice.common.exception.advice;
+
+
+import lombok.RequiredArgsConstructor;
+import me.kong.groupservice.common.exception.DuplicateElementException;
+import me.kong.groupservice.common.exception.ErrorInfo;
+import me.kong.groupservice.common.exception.ForbiddenAccessException;
+import me.kong.groupservice.common.exception.NoLoggedInProfileException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+@RequestMapping("/api/requests")
+@RequiredArgsConstructor
+public class GroupExceptionAdvice {
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ErrorInfo> noSuchElementException(NoSuchElementException e) {
+        return new ResponseEntity<>(new ErrorInfo(e), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(DuplicateElementException.class)
+    public ResponseEntity<ErrorInfo> DuplicateElementException(DuplicateElementException e) {
+        return new ResponseEntity<>(new ErrorInfo(e), HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(ForbiddenAccessException.class)
+    public ResponseEntity<ErrorInfo> ForbiddenAccessException(ForbiddenAccessException e) {
+        return new ResponseEntity<>(new ErrorInfo(e), HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(NoLoggedInProfileException.class)
+    public ResponseEntity<ErrorInfo> NoLoggedInProfileException(NoLoggedInProfileException e) {
+        return new ResponseEntity<>(new ErrorInfo(e.getClass().getSimpleName(), "가입하지 않은 그룹입니다."), HttpStatus.FORBIDDEN);
+    }
+
+}

--- a/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
@@ -3,14 +3,19 @@ package me.kong.groupservice.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.dto.request.GroupJoinRequestDto;
 import me.kong.groupservice.dto.request.SaveGroupRequestDto;
 import me.kong.groupservice.dto.response.GroupResponseDto;
 import me.kong.groupservice.mapper.GroupMapper;
 import me.kong.groupservice.service.GroupService;
+import me.kong.groupservice.service.ProfileService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/groups")
 @RequiredArgsConstructor
@@ -26,4 +31,12 @@ public class GroupController {
 
         return ResponseEntity.ok(groupMapper.toDto(group));
     }
+
+    @PostMapping("{groupId}")
+    public ResponseEntity<HttpStatus> joinGroup(@PathVariable Long groupId, @RequestBody @Valid GroupJoinRequestDto dto) {
+        groupService.joinGroup(dto, groupId);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
 }

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/GroupJoinRequest/GroupJoinRequest.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/GroupJoinRequest/GroupJoinRequest.java
@@ -1,4 +1,4 @@
-package me.kong.groupservice.domain.entity.profile;
+package me.kong.groupservice.domain.entity.GroupJoinRequest;
 
 
 import jakarta.persistence.*;
@@ -7,25 +7,23 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.kong.groupservice.domain.entity.BaseTimeEntity;
-import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.group.Group;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Profile extends BaseTimeEntity {
+public class GroupJoinRequest extends BaseTimeEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue
     private Long id;
+
+    private String requestInfo;
 
     private String nickname;
 
-    @Column(name = "group_role")
+    @Column(name = "response")
     @Enumerated(EnumType.STRING)
-    private GroupRole groupRole;
-
-    @Enumerated(EnumType.STRING)
-    private State state;
+    private JoinResponse response;
 
     @Column(name = "user_id")
     private Long userId;
@@ -35,15 +33,12 @@ public class Profile extends BaseTimeEntity {
     private Group group;
 
     @Builder
-    public Profile(String nickname, GroupRole groupRole, State state, Long userId, Group group) {
+    public GroupJoinRequest(Long id, String requestInfo, String nickname, JoinResponse response, Long userId, Group group) {
+        this.id = id;
+        this.requestInfo = requestInfo;
         this.nickname = nickname;
-        this.groupRole = groupRole;
-        this.state = state;
+        this.response = response;
         this.userId = userId;
         this.group = group;
-    }
-
-    public void setState(State state) {
-        this.state = state;
     }
 }

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/GroupJoinRequest/JoinResponse.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/GroupJoinRequest/JoinResponse.java
@@ -1,0 +1,7 @@
+package me.kong.groupservice.domain.entity.GroupJoinRequest;
+
+public enum JoinResponse {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/group/Group.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/group/Group.java
@@ -34,16 +34,21 @@ public class Group extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private State state;
 
+    @Column(name = "owner_user_id")
+    private Long ownerUserId;
+
+
     @OneToMany(mappedBy = "group", fetch = FetchType.LAZY)
     private List<Profile> profiles;
 
     @Builder
-    public Group(String name, String description, JoinCondition joinCondition, GroupScope groupScope, State state) {
+    public Group(String name, String description, JoinCondition joinCondition, GroupScope groupScope, State state, Long ownerUserId) {
         this.name = name;
         this.description = description;
         this.joinCondition = joinCondition;
         this.groupScope = groupScope;
         this.state = state;
+        this.ownerUserId = ownerUserId;
     }
 
 }

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/profile/GroupRole.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/profile/GroupRole.java
@@ -1,7 +1,6 @@
 package me.kong.groupservice.domain.entity.profile;
 
 public enum GroupRole {
-    MASTER,
     MANAGER,
     MEMBER
 }

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/GroupJoinRequestRepository.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/GroupJoinRequestRepository.java
@@ -1,0 +1,20 @@
+package me.kong.groupservice.domain.repository;
+
+import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.JoinResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+
+@Repository
+public interface GroupJoinRequestRepository extends JpaRepository<GroupJoinRequest, Long> {
+
+    default boolean pendingRequestExists(Long userId, Long groupId) {
+        return findByResponseAndUserIdAndGroupId(JoinResponse.PENDING, userId, groupId).isPresent();
+    }
+
+    Optional<GroupJoinRequest> findByResponseAndUserIdAndGroupId(JoinResponse response, Long userId, Long groupId);
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/ProfileRepository.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/ProfileRepository.java
@@ -2,6 +2,11 @@ package me.kong.groupservice.domain.repository;
 
 import me.kong.groupservice.domain.entity.profile.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
+    Optional<Profile> findByUserIdAndGroupId(Long userId, Long groupId);
 }

--- a/group-service/src/main/java/me/kong/groupservice/dto/request/GroupJoinRequestDto.java
+++ b/group-service/src/main/java/me/kong/groupservice/dto/request/GroupJoinRequestDto.java
@@ -1,0 +1,16 @@
+package me.kong.groupservice.dto.request;
+
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GroupJoinRequestDto {
+
+    @NotEmpty
+    private String nickname;
+
+    private String requestInfo;
+}

--- a/group-service/src/main/java/me/kong/groupservice/mapper/GroupJoinRequestMapper.java
+++ b/group-service/src/main/java/me/kong/groupservice/mapper/GroupJoinRequestMapper.java
@@ -1,0 +1,28 @@
+package me.kong.groupservice.mapper;
+
+import lombok.RequiredArgsConstructor;
+import me.kong.groupservice.common.JwtReader;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.JoinResponse;
+import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.dto.response.GroupResponseDto;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GroupJoinRequestMapper {
+
+    private final JwtReader jwtReader;
+
+    public GroupJoinRequest toEntity(GroupJoinRequestDto dto, Group group) {
+        return GroupJoinRequest.builder()
+                .requestInfo(dto.getRequestInfo())
+                .nickname(dto.getNickname())
+                .response(JoinResponse.PENDING)
+                .userId(jwtReader.getUserId())
+                .group(group)
+                .build();
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/mapper/GroupMapper.java
+++ b/group-service/src/main/java/me/kong/groupservice/mapper/GroupMapper.java
@@ -1,6 +1,8 @@
 package me.kong.groupservice.mapper;
 
 
+import lombok.RequiredArgsConstructor;
+import me.kong.groupservice.common.JwtReader;
 import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.dto.request.SaveGroupRequestDto;
@@ -8,7 +10,10 @@ import me.kong.groupservice.dto.response.GroupResponseDto;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class GroupMapper {
+
+    private final JwtReader jwtReader;
 
     public Group toEntity(SaveGroupRequestDto dto) {
         return Group.builder()
@@ -17,6 +22,7 @@ public class GroupMapper {
                 .joinCondition(dto.getJoinCondition())
                 .groupScope(dto.getGroupScope())
                 .state(State.GENERAL)
+                .ownerUserId(jwtReader.getUserId())
                 .build();
     }
 

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupJoinRequestService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupJoinRequestService.java
@@ -1,0 +1,29 @@
+package me.kong.groupservice.service;
+
+import lombok.RequiredArgsConstructor;
+import me.kong.groupservice.common.JwtReader;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.repository.GroupJoinRequestRepository;
+import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.mapper.GroupJoinRequestMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GroupJoinRequestService {
+
+    private final JwtReader jwtReader;
+    private final GroupJoinRequestRepository joinRequestRepository;
+    private final GroupJoinRequestMapper joinRequestMapper;
+
+    @Transactional(readOnly = true)
+    public boolean pendingRequestExists(Long groupId) {
+        return joinRequestRepository.pendingRequestExists(jwtReader.getUserId(), groupId);
+    }
+
+    @Transactional
+    public void createNewGroupJoinRequest(GroupJoinRequestDto dto, Group group) {
+        joinRequestRepository.save(joinRequestMapper.toEntity(dto, group));
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupService.java
@@ -2,30 +2,83 @@ package me.kong.groupservice.service;
 
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.kong.groupservice.common.exception.DuplicateElementException;
+import me.kong.groupservice.common.exception.ForbiddenAccessException;
+import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.JoinCondition;
 import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.domain.repository.GroupRepository;
+import me.kong.groupservice.dto.request.GroupJoinRequestDto;
 import me.kong.groupservice.dto.request.SaveGroupRequestDto;
 import me.kong.groupservice.mapper.GroupMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GroupService {
 
     private final GroupRepository groupRepository;
-
+    private final GroupJoinRequestService joinRequestService;
     private final ProfileService profileService;
-
     private final GroupMapper groupMapper;
+
 
     @Transactional
     public Group createNewGroup(SaveGroupRequestDto dto) {
         Group group = groupRepository.save(groupMapper.toEntity(dto));
 
-        profileService.createNewProfile(dto.getNickname(), GroupRole.MASTER, group);
+        profileService.createNewProfile(dto.getNickname(), GroupRole.MANAGER, group);
 
         return group;
+    }
+
+    @Transactional
+    public void joinGroup(GroupJoinRequestDto dto, Long groupId) {
+        Group group = findGroupById(groupId);
+
+        if (joinRequestService.pendingRequestExists(group.getId())) {
+            throw new DuplicateElementException("이미 가입 요청한 그룹입니다.");
+        }
+
+        Optional<Profile> optionalProfile = profileService.getOptionalLoggedInProfile(groupId);
+        if (optionalProfile.isPresent()) {
+
+            Profile profile = optionalProfile.get();
+            switch (profile.getState()) {
+                case RESTRICTED -> {
+                    throw new ForbiddenAccessException("추방당한 회원입니다. userId : " + profile.getUserId());
+                }
+                case GENERAL -> {
+                    throw new DuplicateElementException("이미 가입한 그룹입니다.");
+                }
+                case DELETED -> {
+                    if (group.getJoinCondition() == JoinCondition.OPEN) {
+                        profile.setState(State.GENERAL);
+                    } else {
+                        joinRequestService.createNewGroupJoinRequest(dto, group);
+                    }
+                }
+            }
+        } else {
+            if (group.getJoinCondition() == JoinCondition.OPEN) {
+                profileService.createNewProfile(dto.getNickname(), GroupRole.MEMBER, group);
+            } else {
+                joinRequestService.createNewGroupJoinRequest(dto, group);
+            }
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Group findGroupById(Long id) {
+        return groupRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("찾으려는 그룹이 없습니다. id : " + id));
     }
 }

--- a/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
@@ -34,16 +34,10 @@ public class ProfileService {
         profileRepository.save(profile);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = true, noRollbackFor = NoLoggedInProfileException.class)
     public Profile getLoggedInProfile(Long groupId) {
-        return getOptionalLoggedInProfile(groupId).orElseThrow(NoLoggedInProfileException::new);
-    }
-
-    @Transactional(readOnly = true)
-    public Optional<Profile> getOptionalLoggedInProfile(Long groupId) {
         Long userId = jwtReader.getUserId();
 
-        return profileRepository.findByUserIdAndGroupId(userId, groupId);
+        return profileRepository.findByUserIdAndGroupId(userId, groupId).orElseThrow(NoLoggedInProfileException::new);
     }
-
 }

--- a/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
@@ -2,6 +2,7 @@ package me.kong.groupservice.service;
 
 import lombok.RequiredArgsConstructor;
 import me.kong.groupservice.common.JwtReader;
+import me.kong.groupservice.common.exception.NoLoggedInProfileException;
 import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.entity.group.Group;
@@ -9,6 +10,9 @@ import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.domain.repository.ProfileRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
 
 @Service
 @RequiredArgsConstructor
@@ -29,4 +33,17 @@ public class ProfileService {
 
         profileRepository.save(profile);
     }
+
+    @Transactional(readOnly = true)
+    public Profile getLoggedInProfile(Long groupId) {
+        return getOptionalLoggedInProfile(groupId).orElseThrow(NoLoggedInProfileException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Profile> getOptionalLoggedInProfile(Long groupId) {
+        Long userId = jwtReader.getUserId();
+
+        return profileRepository.findByUserIdAndGroupId(userId, groupId);
+    }
+
 }

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupJoinRequestServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupJoinRequestServiceTest.java
@@ -1,0 +1,79 @@
+package me.kong.groupservice.service;
+
+import me.kong.groupservice.common.JwtReader;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.repository.GroupJoinRequestRepository;
+import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.mapper.GroupJoinRequestMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class GroupJoinRequestServiceTest {
+
+    @InjectMocks
+    GroupJoinRequestService groupJoinRequestService;
+
+    @Mock
+    GroupJoinRequestRepository groupJoinRequestRepository;
+
+    @Mock
+    GroupJoinRequestMapper groupJoinRequestMapper;
+
+    @Mock
+    JwtReader jwtReader;
+
+
+    GroupJoinRequest request;
+    GroupJoinRequestDto dto;
+    Group group;
+
+    @BeforeEach
+    void init() {
+        group = mock(Group.class);
+        request = mock(GroupJoinRequest.class);
+        dto = GroupJoinRequestDto.builder()
+                .requestInfo("sample")
+                .nickname("testuser")
+                .build();
+    }
+
+    @Test
+    @DisplayName("그룹 가입 요청 생성에 성공한다")
+    void successToCreateNewGroupJoinRequest() {
+        //given
+        when(groupJoinRequestMapper.toEntity(any(GroupJoinRequestDto.class), any(Group.class)))
+                .thenReturn(request);
+
+        //when
+        groupJoinRequestService.createNewGroupJoinRequest(dto, group);
+
+        //then
+        verify(groupJoinRequestRepository, times(1)).save(request);
+        verify(groupJoinRequestMapper, times(1)).toEntity(dto, group);
+    }
+
+    @Test
+    @DisplayName("데이터베이스에 문제가 있을 경우 예외가 발생한다")
+    void failedByDatabaseProblem() {
+        //given
+        when(groupJoinRequestRepository.save(any())).thenThrow(RuntimeException.class);
+
+        //then
+        assertThrows(RuntimeException.class, () -> groupJoinRequestService.createNewGroupJoinRequest(dto, group));
+    }
+
+}

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupServiceTest.java
@@ -33,14 +33,19 @@ class GroupServiceTest {
     @Mock
     GroupMapper groupMapper;
 
+    SaveGroupRequestDto dto;
+    Group group;
+
+    @BeforeEach
+    void init() {
+        dto = mock(SaveGroupRequestDto.class);
+        group = mock(Group.class);
+    }
 
     @Test
     @DisplayName("그룹 생성에 성공한다")
     void successToCreateNewGroup() {
         //given
-        SaveGroupRequestDto dto = mock();
-        Group group = mock();
-
         when(groupMapper.toEntity(any(SaveGroupRequestDto.class))).thenReturn(group);
 
         //when
@@ -49,5 +54,15 @@ class GroupServiceTest {
         //then
         verify(groupRepository, times(1)).save(any(Group.class));
         verify(groupMapper, times(1)).toEntity(any(SaveGroupRequestDto.class));
+    }
+
+    @Test
+    @DisplayName("데이터베이스 문제가 있을 경우 예외가 발생한다")
+    void failToCreateNewGroupByDatabaseProblem() {
+        //given
+        when(groupRepository.save(any())).thenThrow(RuntimeException.class);
+
+        //then
+        assertThrows(RuntimeException.class, () -> groupService.createNewGroup(dto));
     }
 }

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupServiceTest.java
@@ -1,9 +1,16 @@
 package me.kong.groupservice.service;
 
+import me.kong.groupservice.common.exception.DuplicateElementException;
+import me.kong.groupservice.common.exception.ForbiddenAccessException;
+import me.kong.groupservice.common.exception.NoLoggedInProfileException;
+import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.domain.entity.group.GroupScope;
 import me.kong.groupservice.domain.entity.group.JoinCondition;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
+import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.domain.repository.GroupRepository;
+import me.kong.groupservice.dto.request.GroupJoinRequestDto;
 import me.kong.groupservice.dto.request.SaveGroupRequestDto;
 import me.kong.groupservice.mapper.GroupMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +20,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,15 +40,30 @@ class GroupServiceTest {
     ProfileService profileService;
 
     @Mock
+    GroupJoinRequestService joinRequestService;
+
+    @Mock
     GroupMapper groupMapper;
 
     SaveGroupRequestDto dto;
+    GroupJoinRequestDto joinRequestDto;
     Group group;
+    Profile profile;
+
+    String groupName;
+    String description;
+    String nickname;
 
     @BeforeEach
     void init() {
         dto = mock(SaveGroupRequestDto.class);
+        joinRequestDto = GroupJoinRequestDto.builder()
+                .nickname("testUser")
+                .build();
         group = mock(Group.class);
+        groupName = "test group";
+        description = "테스트 그룹입니다";
+        nickname = "testNickname";
     }
 
     @Test
@@ -64,5 +88,124 @@ class GroupServiceTest {
 
         //then
         assertThrows(RuntimeException.class, () -> groupService.createNewGroup(dto));
+    }
+
+
+    @Test
+    @DisplayName("OPEN 그룹에 새로 가입 요청 시 새로운 프로필이 등록된다")
+    void successToJoinOpenGroup() {
+        //given
+        group = makeGroup(JoinCondition.OPEN);
+
+        when(joinRequestService.pendingRequestExists(any())).thenReturn(false);
+        when(profileService.getLoggedInProfile(any())).thenThrow(NoLoggedInProfileException.class);
+        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
+
+        //when
+        groupService.joinGroup(joinRequestDto, any(Long.class));
+
+        //then
+        verify(profileService, times(1))
+                .createNewProfile(joinRequestDto.getNickname(), GroupRole.MEMBER, group);
+    }
+
+    @Test
+    @DisplayName("APPROVAL_REQUIRED 그룹에 새로 가입 요청 시 GroupJoinRequest가 생성된다")
+    void successToJoinApprovalRequired() {
+        //given
+        group = makeGroup(JoinCondition.APPROVAL_REQUIRED);
+
+        when(joinRequestService.pendingRequestExists(any())).thenReturn(false);
+        when(profileService.getLoggedInProfile(any())).thenThrow(NoLoggedInProfileException.class);
+        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
+
+        //when
+        groupService.joinGroup(joinRequestDto, any(Long.class));
+
+        //then
+        verify(joinRequestService, times(1))
+                .createNewGroupJoinRequest(any(GroupJoinRequestDto.class), any(Group.class));
+    }
+
+    @Test
+    @DisplayName("OPEN 그룹 가입 시 탈퇴한 전적이 존재하면 이전 프로필을 되살린다")
+    void successToJoinWithPreviousProfile() {
+        //given
+        group = makeGroup(JoinCondition.OPEN);
+        profile = makeProfile(GroupRole.MEMBER, State.DELETED);
+
+        when(joinRequestService.pendingRequestExists(any())).thenReturn(false);
+        when(profileService.getLoggedInProfile(any())).thenReturn(profile);
+        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
+
+        //when
+        groupService.joinGroup(joinRequestDto, any(Long.class));
+
+        //then
+        assertEquals(State.GENERAL, profile.getState());
+    }
+
+    @Test
+    @DisplayName("APPROVAL_REQUIRED 그룹에 탈퇴한 전적이 존재하면 GroupJoinRequest가 생성된다")
+    void successToJoinApprovalRequiredWithPreviousProfile() {
+        //given
+        group = makeGroup(JoinCondition.APPROVAL_REQUIRED);
+        profile = makeProfile(GroupRole.MEMBER, State.DELETED);
+
+        when(joinRequestService.pendingRequestExists(any())).thenReturn(false);
+        when(profileService.getLoggedInProfile(any())).thenReturn(profile);
+        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
+
+        //when
+        groupService.joinGroup(joinRequestDto, any(Long.class));
+
+        //then
+        verify(joinRequestService, times(1))
+                .createNewGroupJoinRequest(any(GroupJoinRequestDto.class), any(Group.class));
+    }
+
+    @Test
+    @DisplayName("대기중인 가입 요청이 있다면 DuplicateElementException이 발생한다")
+    void failToJoinByPendingRequestExist() {
+        //given
+        when(joinRequestService.pendingRequestExists(any())).thenReturn(true);
+        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
+
+        //then
+        assertThrows(DuplicateElementException.class, () -> groupService.joinGroup(joinRequestDto, any(Long.class)));
+    }
+
+    @Test
+    @DisplayName("추방당한 전적이 있다면 ForbiddenAccessException이 발생한다")
+    void failToJoinByPreviousBanRecord() {
+        //given
+        profile = makeProfile(GroupRole.MEMBER, State.RESTRICTED);
+        when(joinRequestService.pendingRequestExists(any())).thenReturn(false);
+        when(profileService.getLoggedInProfile(any())).thenReturn(profile);
+        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
+
+        //then
+        assertThrows(ForbiddenAccessException.class, () -> groupService.joinGroup(joinRequestDto, any(Long.class)));
+    }
+
+
+    private Group makeGroup(JoinCondition joinCondition) {
+        return Group.builder()
+                .name(groupName)
+                .description(description)
+                .groupScope(GroupScope.PUBLIC)
+                .joinCondition(joinCondition)
+                .ownerUserId(1L)
+                .build();
+    }
+
+    private Profile makeProfile(GroupRole groupRole, State state) {
+        return Profile.builder()
+                .nickname(nickname)
+                .groupRole(groupRole)
+                .state(state)
+                .group(group)
+                .userId(1L)
+                .build();
     }
 }

--- a/group-service/src/test/java/me/kong/groupservice/service/ProfileServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/ProfileServiceTest.java
@@ -5,6 +5,7 @@ import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.domain.repository.ProfileRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,14 +29,22 @@ class ProfileServiceTest {
     @Mock
     JwtReader jwtReader;
 
+    String nickname;
+    GroupRole groupRole;
+    Group group;
+
+    @BeforeEach
+    void init() {
+        nickname = "testUser";
+        groupRole = GroupRole.MANAGER;
+        group = mock(Group.class);
+    }
+
 
     @Test
     @DisplayName("프로필 생성에 성공한다")
     void successToCreateNewProfile() {
         // Given
-        String nickname = "testUser";
-        GroupRole groupRole = GroupRole.MEMBER;
-        Group group = mock(Group.class);
         when(jwtReader.getUserId()).thenReturn(1L);
 
         //when
@@ -44,5 +53,15 @@ class ProfileServiceTest {
         //then
         verify(jwtReader, times(1)).getUserId();
         verify(profileRepository, times(1)).save(any(Profile.class));
+    }
+
+    @Test
+    @DisplayName("데이터베이스 문제가 있을 경우 예외가 발생한다")
+    void failToCreateNewProfileByDatabaseProblem() {
+        //given
+        when(profileRepository.save(any())).thenThrow(RuntimeException.class);
+
+        //then
+        assertThrows(RuntimeException.class, () -> profileService.createNewProfile(nickname, groupRole, group));
     }
 }

--- a/group-service/src/test/java/me/kong/groupservice/validation/GroupJoinRequestValidationTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/validation/GroupJoinRequestValidationTest.java
@@ -1,0 +1,54 @@
+package me.kong.groupservice.validation;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
+import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.dto.request.SaveGroupRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GroupJoinRequestValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void init() {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @Test
+    @DisplayName("모두 정상적으로 입력받았을 경우 검증에 성공한다")
+    void successToCreateNewGroupJoinRequest() {
+        GroupJoinRequestDto dto = GroupJoinRequestDto.builder()
+                .nickname("testUser")
+                .requestInfo("info")
+                .build();
+
+        Set<ConstraintViolation<GroupJoinRequestDto>> violations = validator.validate(dto);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("닉네임이 비어있을 경우 변환에 실패한다")
+    void failedByEmptyNickname() {
+        GroupJoinRequestDto dto = GroupJoinRequestDto.builder()
+                .nickname("")
+                .requestInfo("info")
+                .build();
+
+        Set<ConstraintViolation<GroupJoinRequestDto>> violations = validator.validate(dto);
+        ConstraintViolation<GroupJoinRequestDto> violation = violations.iterator().next();
+        assertEquals("nickname", violation.getPropertyPath().toString());
+        assertEquals("비어 있을 수 없습니다", violation.getMessage());
+    }
+}

--- a/group-service/src/test/java/me/kong/groupservice/validation/GroupValidationTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/validation/GroupValidationTest.java
@@ -1,4 +1,4 @@
-package me.kong.groupservice.service;
+package me.kong.groupservice.validation;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;


### PR DESCRIPTION
## 구현 기능
- 그룹 가입 flow에 따른 비즈니스 로직 작성
- 그룹 가입 요청 entity 클래스 및 서비스 로직 작성
- advice를 통한 전역 예외처리 구현

## 개발 코멘트
- Group 테이블에 그룹 주인을 인식하기 위한 owner_user_id 필드를 생성했습니다.
- 기존의 GroupRole 중 MASTER 타입을 제거했습니다.