### PR TITLE
[#3] 가입 요청 처리 API 변경

### DIFF
--- a/docs/api-docs
+++ b/docs/api-docs
@@ -218,18 +218,29 @@ paths:
         '409':
           description: 이미 가입한 사용자
           
-  /requests:
+  /groups/{groupId}/requests:
     get:
       tags:
         - groups
       summary: 가입요청 목록 요청
-      description: 가입 대기중인 요청 중 처리되지 않은 요청들을 반환합니다.
+      description: 가입 요청 목록을 반환합니다. status 파라미터 미전달 시 대기중인 요청만 반환됩니다.
       parameters:
-        - in: query
+        - in: path
           name: groupId
           required: true
           schema:
             type: integer
+        - in: query
+          name: status
+          required: false
+          schema:
+            type: string
+            enum:
+              - PENDING
+              - PROCESSED
+              - ALL
+            default: PENDING
+            # description: 조회할 가입 요청의 상태 (PENDING: 대기중, PROCESSED: 처리됨, ALL: 모든 요청)
       responses:
         '200':
           description: 요청 목록 반환 성공
@@ -253,14 +264,19 @@ paths:
           description: 권한 부족
         '404':
           description: 존재하지 않는 그룹
-  
-  /requests/{requestId}:
+    
+  /groups/{groupId}/requests/{requestId}:
     patch:
       tags:
         - groups
       summary: 가입 요청 처리
       description: 요청에 대해 수락/거절 처리를 진행합니다
       parameters:
+        - in: path
+          name: groupId
+          required: true
+          schema:
+            type: integer
         - in: path
           name: requestId
           required: true
@@ -287,4 +303,5 @@ paths:
           description: 존재하지 않는 그룹 혹은 요청 정보
         '409':
           description: 이미 처리된 요청
+          
         

--- a/docs/api-docs
+++ b/docs/api-docs
@@ -292,8 +292,8 @@ paths:
                   type: string
                   description: 요청 처리에 기대하는 동작
                   enum: 
-                    - APPROVED
-                    - REJECTED
+                    - APPROVE
+                    - REJECT
       responses:
         '200':
           description: 처리 성공

--- a/docs/api-docs
+++ b/docs/api-docs
@@ -288,7 +288,7 @@ paths:
             schema:
               type: object
               properties:
-                email: 
+                action: 
                   type: string
                   description: 요청 처리에 기대하는 동작
                   enum: 


### PR DESCRIPTION
### 추가된 API
없음

### 업데이트된 API
#### 요청 조회 API
- 경로 변경 : /requests --> /groups/{groupId}/requests
- 검색 조건 추가 : 검색 조건을 통해 처리했던 요청들 또한 요청할 수 있도록 수정했습니다

#### 요청 처리 API
- 경로 변경 : /requests/{requestId} --> /groups/{groupId}/requests/{requestId}

### 추가 정보
- 기존 경로인 /requests 는 "그룹 요청 처리" 라는 의미를 담기 부족하다고 생각해 변경하였습니다.