### PR TITLE
[#15] 그룹 요청 처리 기능 구현

### DIFF
--- a/group-service/build.gradle
+++ b/group-service/build.gradle
@@ -18,6 +18,7 @@ configurations {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
@@ -30,6 +31,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'me.kong:common-library:0.0.1-SNAPSHOT'
 }
 
 tasks.named('test') {

--- a/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
@@ -5,15 +5,23 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.dto.request.GroupJoinProcessDto;
 import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.dto.request.enums.JoinRequestSearchCondition;
 import me.kong.groupservice.dto.request.SaveGroupRequestDto;
+import me.kong.groupservice.dto.response.GroupJoinResponseDto;
 import me.kong.groupservice.dto.response.GroupResponseDto;
+import me.kong.groupservice.mapper.GroupJoinRequestMapper;
 import me.kong.groupservice.mapper.GroupMapper;
+import me.kong.groupservice.service.GroupJoinRequestService;
 import me.kong.groupservice.service.GroupService;
-import me.kong.groupservice.service.ProfileService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static me.kong.commonlibrary.constant.HttpStatusResponseEntity.RESPONSE_OK;
 
 @Slf4j
 @RestController
@@ -22,8 +30,9 @@ import org.springframework.web.bind.annotation.*;
 public class GroupController {
 
     private final GroupService groupService;
-
+    private final GroupJoinRequestService joinRequestService;
     private final GroupMapper groupMapper;
+    private final GroupJoinRequestMapper requestMapper;
 
     @PostMapping
     public ResponseEntity<GroupResponseDto> addGroup(@RequestBody @Valid SaveGroupRequestDto dto) {
@@ -39,4 +48,21 @@ public class GroupController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
+    @GetMapping("{groupId}/requests")
+    public ResponseEntity<List<GroupJoinResponseDto>> getGroupRequests(
+            @PathVariable Long groupId,
+            @RequestParam(name = "status", defaultValue = "PENDING") JoinRequestSearchCondition condition) {
+        List<GroupJoinResponseDto> requests = requestMapper.toDtoList(joinRequestService.getGroupJoinRequestsByGroupIdAndCondition(groupId, condition));
+
+        return new ResponseEntity<>(requests, HttpStatus.OK);
+    }
+
+    @PatchMapping("{groupId}/requests/{requestId}")
+    public ResponseEntity<HttpStatus> handleGroupJoinRequest(@PathVariable Long groupId,
+                                                             @PathVariable Long requestId,
+                                                             @RequestBody GroupJoinProcessDto processDto) {
+        joinRequestService.processGroupJoinRequest(requestId, processDto);
+
+        return RESPONSE_OK;
+    }
 }

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/GroupJoinRequest/GroupJoinRequest.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/GroupJoinRequest/GroupJoinRequest.java
@@ -41,4 +41,12 @@ public class GroupJoinRequest extends BaseTimeEntity {
         this.userId = userId;
         this.group = group;
     }
+
+    public void approveJoinRequest() {
+        response = JoinResponse.APPROVED;
+    }
+
+    public void rejectJoinRequest() {
+        response = JoinResponse.REJECTED;
+    }
 }

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/GroupJoinRequestRepository.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/GroupJoinRequestRepository.java
@@ -17,4 +17,18 @@ public interface GroupJoinRequestRepository extends JpaRepository<GroupJoinReque
     }
 
     Optional<GroupJoinRequest> findByResponseAndUserIdAndGroupId(JoinResponse response, Long userId, Long groupId);
+
+    List<GroupJoinRequest> findAllByGroupId(Long groupId);
+
+    default List<GroupJoinRequest> findPendingGroupJoinRequests(Long groupId) {
+        return findAllByGroupIdAndResponse(groupId, JoinResponse.PENDING);
+    }
+
+    default List<GroupJoinRequest> findProcessedGroupJoinRequests(Long groupId) {
+        return findAllByGroupIdAndResponseNot(groupId, JoinResponse.PENDING);
+    }
+
+    List<GroupJoinRequest> findAllByGroupIdAndResponse(Long groupId, JoinResponse response);
+
+    List<GroupJoinRequest> findAllByGroupIdAndResponseNot(Long groupId, JoinResponse response);
 }

--- a/group-service/src/main/java/me/kong/groupservice/dto/request/GroupJoinProcessDto.java
+++ b/group-service/src/main/java/me/kong/groupservice/dto/request/GroupJoinProcessDto.java
@@ -1,0 +1,19 @@
+package me.kong.groupservice.dto.request;
+
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.kong.groupservice.dto.request.enums.GroupJoinProcessAction;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupJoinProcessDto {
+
+    @NotNull
+    private GroupJoinProcessAction action;
+}

--- a/group-service/src/main/java/me/kong/groupservice/dto/request/enums/GroupJoinProcessAction.java
+++ b/group-service/src/main/java/me/kong/groupservice/dto/request/enums/GroupJoinProcessAction.java
@@ -1,0 +1,6 @@
+package me.kong.groupservice.dto.request.enums;
+
+public enum GroupJoinProcessAction {
+    APPROVE,
+    REJECT;
+}

--- a/group-service/src/main/java/me/kong/groupservice/dto/request/enums/JoinRequestSearchCondition.java
+++ b/group-service/src/main/java/me/kong/groupservice/dto/request/enums/JoinRequestSearchCondition.java
@@ -1,0 +1,7 @@
+package me.kong.groupservice.dto.request.enums;
+
+public enum JoinRequestSearchCondition {
+    PENDING,
+    PROCESSED,
+    ALL;
+}

--- a/group-service/src/main/java/me/kong/groupservice/dto/response/GroupJoinResponseDto.java
+++ b/group-service/src/main/java/me/kong/groupservice/dto/response/GroupJoinResponseDto.java
@@ -1,0 +1,15 @@
+package me.kong.groupservice.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.JoinResponse;
+
+@Getter
+@Builder
+public class GroupJoinResponseDto {
+    private Long requestId;
+    private String nickname;
+    private String requestInfo;
+    private JoinResponse status;
+    private Long userId;
+}

--- a/group-service/src/main/java/me/kong/groupservice/mapper/GroupJoinRequestMapper.java
+++ b/group-service/src/main/java/me/kong/groupservice/mapper/GroupJoinRequestMapper.java
@@ -7,8 +7,11 @@ import me.kong.groupservice.domain.entity.GroupJoinRequest.JoinResponse;
 import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.dto.response.GroupJoinResponseDto;
 import me.kong.groupservice.dto.response.GroupResponseDto;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -24,5 +27,21 @@ public class GroupJoinRequestMapper {
                 .userId(jwtReader.getUserId())
                 .group(group)
                 .build();
+    }
+
+    public GroupJoinResponseDto toDto(GroupJoinRequest request) {
+        return GroupJoinResponseDto.builder()
+                .requestId(request.getId())
+                .nickname(request.getNickname())
+                .requestInfo(request.getRequestInfo())
+                .status(request.getResponse())
+                .userId(request.getUserId())
+                .build();
+    }
+
+    public List<GroupJoinResponseDto> toDtoList(List<GroupJoinRequest> requests) {
+        return requests.stream()
+                .map(this::toDto)
+                .toList();
     }
 }

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupJoinRequestService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupJoinRequestService.java
@@ -2,12 +2,21 @@ package me.kong.groupservice.service;
 
 import lombok.RequiredArgsConstructor;
 import me.kong.groupservice.common.JwtReader;
+import me.kong.groupservice.common.exception.DuplicateElementException;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.JoinResponse;
 import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.repository.GroupJoinRequestRepository;
+import me.kong.groupservice.dto.request.GroupJoinProcessDto;
 import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.dto.request.enums.JoinRequestSearchCondition;
 import me.kong.groupservice.mapper.GroupJoinRequestMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +25,14 @@ public class GroupJoinRequestService {
     private final JwtReader jwtReader;
     private final GroupJoinRequestRepository joinRequestRepository;
     private final GroupJoinRequestMapper joinRequestMapper;
+    private final GroupJoinRequestRepository groupJoinRequestRepository;
+    private final ProfileService profileService;
+
+    @Transactional(readOnly = true)
+    public GroupJoinRequest getGroupJoinRequestByRequestId(Long requestId) {
+        return joinRequestRepository.findById(requestId)
+                .orElseThrow(() -> new NoSuchElementException("해당하는 가입 요청이 없습니다. id : " + requestId));
+    }
 
     @Transactional(readOnly = true)
     public boolean pendingRequestExists(Long groupId) {
@@ -25,5 +42,52 @@ public class GroupJoinRequestService {
     @Transactional
     public void createNewGroupJoinRequest(GroupJoinRequestDto dto, Group group) {
         joinRequestRepository.save(joinRequestMapper.toEntity(dto, group));
+    }
+
+    @Transactional(readOnly = true)
+    public List<GroupJoinRequest> getGroupJoinRequestsByGroupIdAndCondition(Long groupId, JoinRequestSearchCondition condition) {
+        List<GroupJoinRequest> requests;
+
+        profileService.checkLoggedInProfileIsGroupManager(groupId);
+
+        switch (condition) {
+            case PENDING -> {
+                requests = groupJoinRequestRepository.findPendingGroupJoinRequests(groupId);
+            }
+            case PROCESSED -> {
+                requests = groupJoinRequestRepository.findProcessedGroupJoinRequests(groupId);
+            }
+            case ALL -> {
+                requests = groupJoinRequestRepository.findAllByGroupId(groupId);
+            }
+            default -> {
+                throw new IllegalArgumentException("지원하지 않는 그룹 가입 검색 조건. status : " + condition);
+            }
+        }
+        return requests;
+    }
+
+    @Transactional
+    public void processGroupJoinRequest(Long requestId, GroupJoinProcessDto dto) {
+        GroupJoinRequest joinRequest = getGroupJoinRequestByRequestId(requestId);
+
+        if (joinRequest.getResponse() != JoinResponse.PENDING) {
+            throw new DuplicateElementException("이미 처리된 가입 요청입니다. 요청 id : " + requestId);
+        }
+
+        profileService.checkLoggedInProfileIsGroupManager(joinRequest.getGroup().getId());
+
+        switch (dto.getAction()) {
+            case APPROVE -> {
+                joinRequest.approveJoinRequest();
+                profileService.createNewProfile(joinRequest.getNickname(), GroupRole.MEMBER, joinRequest.getGroup());
+            }
+            case REJECT -> {
+                joinRequest.rejectJoinRequest();
+            }
+            default -> {
+                throw new IllegalArgumentException("지원하지 않는 처리 요청. action : " + dto.getAction());
+            }
+        }
     }
 }

--- a/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
@@ -1,6 +1,7 @@
 package me.kong.groupservice.service;
 
 import lombok.RequiredArgsConstructor;
+import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
 import me.kong.groupservice.common.JwtReader;
 import me.kong.groupservice.common.exception.NoLoggedInProfileException;
 import me.kong.groupservice.domain.entity.State;
@@ -11,7 +12,6 @@ import me.kong.groupservice.domain.repository.ProfileRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
 
 
 @Service
@@ -39,5 +39,15 @@ public class ProfileService {
         Long userId = jwtReader.getUserId();
 
         return profileRepository.findByUserIdAndGroupId(userId, groupId).orElseThrow(NoLoggedInProfileException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public void checkLoggedInProfileIsGroupManager(Long groupId) {
+        Profile profile = getLoggedInProfile(groupId);
+
+        if (profile.getGroupRole() != GroupRole.MANAGER) {
+            throw new UnAuthorizedException("권한이 없습니다. groupId : "
+                    + groupId + ", profileId : " + profile.getId() + " , userId : " + profile.getUserId());
+        }
     }
 }

--- a/group-service/src/test/java/me/kong/groupservice/integration/GroupManagementServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/integration/GroupManagementServiceTest.java
@@ -8,13 +8,12 @@ import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.repository.GroupRepository;
 import me.kong.groupservice.domain.repository.ProfileRepository;
 import me.kong.groupservice.dto.request.SaveGroupRequestDto;
+import me.kong.groupservice.service.GroupJoinRequestService;
 import me.kong.groupservice.service.GroupService;
 import me.kong.groupservice.service.ProfileService;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -28,6 +27,9 @@ public class GroupManagementServiceTest {
 
     @Autowired
     private GroupService groupService;
+
+    @Autowired
+    private GroupJoinRequestService joinRequestService;
 
     @MockBean
     private ProfileService profileService;

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupJoinRequestServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupJoinRequestServiceTest.java
@@ -1,20 +1,26 @@
 package me.kong.groupservice.service;
 
 import me.kong.groupservice.common.JwtReader;
+import me.kong.groupservice.common.exception.DuplicateElementException;
 import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.JoinResponse;
 import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.repository.GroupJoinRequestRepository;
+import me.kong.groupservice.dto.request.GroupJoinProcessDto;
 import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.dto.request.enums.GroupJoinProcessAction;
+import me.kong.groupservice.dto.request.enums.JoinRequestSearchCondition;
 import me.kong.groupservice.mapper.GroupJoinRequestMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,6 +32,9 @@ class GroupJoinRequestServiceTest {
 
     @InjectMocks
     GroupJoinRequestService groupJoinRequestService;
+
+    @Mock
+    ProfileService profileService;
 
     @Mock
     GroupJoinRequestRepository groupJoinRequestRepository;
@@ -40,6 +49,9 @@ class GroupJoinRequestServiceTest {
     GroupJoinRequest request;
     GroupJoinRequestDto dto;
     Group group;
+    Long groupId;
+    JoinRequestSearchCondition condition;
+    GroupJoinProcessDto processDto;
 
     @BeforeEach
     void init() {
@@ -49,6 +61,7 @@ class GroupJoinRequestServiceTest {
                 .requestInfo("sample")
                 .nickname("testuser")
                 .build();
+        groupId = 1L;
     }
 
     @Test
@@ -76,4 +89,110 @@ class GroupJoinRequestServiceTest {
         assertThrows(RuntimeException.class, () -> groupJoinRequestService.createNewGroupJoinRequest(dto, group));
     }
 
+    @Test
+    @DisplayName("searchCondition이 ALL이라면 해당 그룹의 모든 그룹 가입 요청을 조회한다")
+    void successToFindAllGroupJoinRequests() {
+        //given
+        JoinRequestSearchCondition condition = JoinRequestSearchCondition.ALL;
+
+        //when
+        groupJoinRequestService.getGroupJoinRequestsByGroupIdAndCondition(groupId, condition);
+
+        //then
+        verify(groupJoinRequestRepository, times(1)).findAllByGroupId(groupId);
+    }
+
+    @Test
+    @DisplayName("searchCondition이 PENDING이라면 해당 그룹의 대기중인 그룹 가입 요청을 조회한다")
+    void successToFindPendingGroupJOinRequests() {
+        //given
+        condition = JoinRequestSearchCondition.PENDING;
+
+        //when
+        groupJoinRequestService.getGroupJoinRequestsByGroupIdAndCondition(groupId, condition);
+
+        //then
+        verify(groupJoinRequestRepository, times(1))
+                .findPendingGroupJoinRequests(groupId);
+    }
+
+    @Test
+    @DisplayName("searchCondition이 PROCESSED라면 처리된 그룹 가입 요청을 조회한다")
+    void successToFindProcessedGroupJoinRequests() {
+        //given
+        condition = JoinRequestSearchCondition.PROCESSED;
+
+        //when
+        groupJoinRequestService.getGroupJoinRequestsByGroupIdAndCondition(groupId, condition);
+
+        //then
+        verify(groupJoinRequestRepository, times(1))
+                .findProcessedGroupJoinRequests(groupId);
+    }
+
+    @Test
+    @DisplayName("가입 승인 시, 우 가입 요청 상태가 승인으로 변경되고 새로운 프로필을 생성한다")
+    void successToApproveGroupJoinRequest() {
+        //given
+        Long requestId = 1L;
+        processDto = getProcessDto(GroupJoinProcessAction.APPROVE);
+        request = getJoinRequest(JoinResponse.PENDING);
+        when(groupJoinRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+        doNothing().when(profileService).checkLoggedInProfileIsGroupManager(anyLong());
+
+        // when
+        groupJoinRequestService.processGroupJoinRequest(requestId, processDto);
+
+        // then
+        assertEquals(JoinResponse.APPROVED, request.getResponse());
+        verify(profileService, times(1)).createNewProfile(request.getNickname(), GroupRole.MEMBER, request.getGroup());
+    }
+
+    @Test
+    @DisplayName("가입 거절 시, 가입 요청 상태가 거절로 변경된다")
+    void successToRejectGroupJoinRequest() {
+        //given
+        Long requestId = 1L;
+        processDto = getProcessDto(GroupJoinProcessAction.REJECT);
+        request = getJoinRequest(JoinResponse.PENDING);
+        when(groupJoinRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+        doNothing().when(profileService).checkLoggedInProfileIsGroupManager(anyLong());
+
+        //when
+        groupJoinRequestService.processGroupJoinRequest(requestId, processDto);
+
+        //then
+        assertEquals(JoinResponse.REJECTED, request.getResponse());
+    }
+
+
+    @Test
+    @DisplayName("가입 요청이 이미 처리되었다면 예외가 발생한다")
+    void testProcessGroupJoinRequest_AlreadyProcessed() {
+        // given
+        Long requestId = 1L;
+        processDto = getProcessDto(GroupJoinProcessAction.APPROVE);
+        request = getJoinRequest(JoinResponse.APPROVED);
+        when(groupJoinRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+
+        // then
+        assertThrows(DuplicateElementException.class, () -> {
+            groupJoinRequestService.processGroupJoinRequest(requestId, processDto);
+        });
+    }
+
+
+
+    private GroupJoinProcessDto getProcessDto(GroupJoinProcessAction action) {
+        return GroupJoinProcessDto.builder()
+                .action(action)
+                .build();
+    }
+
+    private GroupJoinRequest getJoinRequest(JoinResponse response) {
+        return GroupJoinRequest.builder()
+                .response(response)
+                .group(group)
+                .build();
+    }
 }

--- a/group-service/src/test/java/me/kong/groupservice/service/ProfileServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/ProfileServiceTest.java
@@ -1,6 +1,8 @@
 package me.kong.groupservice.service;
 
+import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
 import me.kong.groupservice.common.JwtReader;
+import me.kong.groupservice.common.exception.NoLoggedInProfileException;
 import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.entity.profile.Profile;
@@ -12,6 +14,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -63,5 +67,21 @@ class ProfileServiceTest {
 
         //then
         assertThrows(RuntimeException.class, () -> profileService.createNewProfile(nickname, groupRole, group));
+    }
+
+    @Test
+    @DisplayName("그룹 매니저가 아닐 경우 예외가 발생한다")
+    void unAuthorizeOccurred() {
+        //given
+        Long userId = 1L;
+        Long groupId = 1L;
+        Profile profile = Profile.builder()
+                .groupRole(GroupRole.MEMBER)
+                .build();
+        when(jwtReader.getUserId()).thenReturn(userId);
+        when(profileRepository.findByUserIdAndGroupId(userId, groupId)).thenReturn(Optional.of(profile));
+
+        //then
+        assertThrows(UnAuthorizedException.class, () -> profileService.checkLoggedInProfileIsGroupManager(groupId));
     }
 }

--- a/group-service/src/test/java/me/kong/groupservice/validation/GroupJoinRequestValidationTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/validation/GroupJoinRequestValidationTest.java
@@ -4,9 +4,9 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
-import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
+import me.kong.groupservice.dto.request.GroupJoinProcessDto;
 import me.kong.groupservice.dto.request.GroupJoinRequestDto;
-import me.kong.groupservice.dto.request.SaveGroupRequestDto;
+import me.kong.groupservice.dto.request.enums.GroupJoinProcessAction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,5 +50,29 @@ public class GroupJoinRequestValidationTest {
         ConstraintViolation<GroupJoinRequestDto> violation = violations.iterator().next();
         assertEquals("nickname", violation.getPropertyPath().toString());
         assertEquals("비어 있을 수 없습니다", violation.getMessage());
+    }
+
+    @Test
+    @DisplayName("가입 요청 처리의 action이 존재한다면 검증에 성공한다")
+    void successToProcessGroupJoinRequest() {
+        GroupJoinProcessDto dto = GroupJoinProcessDto.builder()
+                .action(GroupJoinProcessAction.APPROVE)
+                .build();
+
+        Set<ConstraintViolation<GroupJoinProcessDto>> violations = validator.validate(dto);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("가입 요청 처리의 action이 비어있다면 검증에 실패한다")
+    void failedByEmptyAction() {
+        GroupJoinProcessDto dto = GroupJoinProcessDto.builder()
+                .action(null)
+                .build();
+
+        Set<ConstraintViolation<GroupJoinProcessDto>> violations = validator.validate(dto);
+        ConstraintViolation<GroupJoinProcessDto> violation = violations.iterator().next();
+        assertEquals("action", violation.getPropertyPath().toString());
+        assertEquals("널이어서는 안됩니다", violation.getMessage());
     }
 }


### PR DESCRIPTION
## 구현 기능
- 그룹 가입 요청 조회
- 그룹 가입 요청 처리

## 개발 코멘트
- 요청 조회는 기본값으론 대기중인 요청만, 파라미터 지정 시 전체 혹은 처리된 요청을 반환 가능합니다.
- 요청 조회 / 처리는 그룹의 매니저에게만 허락됩니다.