### PR TITLE
[#26] 그룹 정원 확인 로직 변경

### DIFF
--- a/group-service/src/main/java/me/kong/groupservice/common/Constants.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/Constants.java
@@ -1,0 +1,8 @@
+package me.kong.groupservice.common;
+
+public final class Constants {
+    public static final int BASIC = 10;
+
+
+    public static final String NoStateExceptionMessage = "선택된 처리 전략 없음({}) : {}";
+}

--- a/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
@@ -13,6 +13,7 @@ import me.kong.groupservice.dto.response.GroupJoinResponseDto;
 import me.kong.groupservice.dto.response.GroupResponseDto;
 import me.kong.groupservice.mapper.GroupJoinRequestMapper;
 import me.kong.groupservice.mapper.GroupMapper;
+import me.kong.groupservice.service.GroupJoinFacade;
 import me.kong.groupservice.service.GroupJoinRequestService;
 import me.kong.groupservice.service.GroupService;
 import org.springframework.http.HttpStatus;
@@ -33,6 +34,7 @@ public class GroupController {
     private final GroupJoinRequestService joinRequestService;
     private final GroupMapper groupMapper;
     private final GroupJoinRequestMapper requestMapper;
+    private final GroupJoinFacade groupJoinFacade;
 
     @PostMapping
     public ResponseEntity<GroupResponseDto> addGroup(@RequestBody @Valid SaveGroupRequestDto dto) {
@@ -43,7 +45,7 @@ public class GroupController {
 
     @PostMapping("{groupId}")
     public ResponseEntity<HttpStatus> joinGroup(@PathVariable Long groupId, @RequestBody @Valid GroupJoinRequestDto dto) {
-        groupService.joinGroup(dto, groupId);
+        groupJoinFacade.joinGroup(dto, groupId);
 
         return ResponseEntity.status(HttpStatus.OK).build();
     }
@@ -61,7 +63,7 @@ public class GroupController {
     public ResponseEntity<HttpStatus> handleGroupJoinRequest(@PathVariable Long groupId,
                                                              @PathVariable Long requestId,
                                                              @RequestBody GroupJoinProcessDto processDto) {
-        joinRequestService.processGroupJoinRequest(requestId, processDto);
+        groupJoinFacade.processGroupJoinRequest(requestId, processDto);
 
         return RESPONSE_OK;
     }

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/GroupJoinRequest/GroupJoinRequest.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/GroupJoinRequest/GroupJoinRequest.java
@@ -14,7 +14,7 @@ import me.kong.groupservice.domain.entity.group.Group;
 @Entity
 public class GroupJoinRequest extends BaseTimeEntity {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String requestInfo;

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/group/Group.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/group/Group.java
@@ -7,10 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.kong.commonlibrary.entity.BaseTimeEntity;
-import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.domain.entity.State;
-
-import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,8 +37,11 @@ public class Group extends BaseTimeEntity {
     @Column(name = "owner_user_id")
     private Long ownerUserId;
 
+    @Column(name = "profile_count")
+    private Integer profileCount;
+
     @Builder
-    public Group(String name, String description, Integer groupSize, JoinCondition joinCondition, GroupScope groupScope, State state, Long ownerUserId) {
+    public Group(String name, String description, Integer groupSize, JoinCondition joinCondition, GroupScope groupScope, State state, Long ownerUserId, Integer profileCount) {
         this.name = name;
         this.description = description;
         this.groupSize = groupSize;
@@ -49,6 +49,15 @@ public class Group extends BaseTimeEntity {
         this.groupScope = groupScope;
         this.state = state;
         this.ownerUserId = ownerUserId;
+        this.profileCount = profileCount;
+    }
+
+    public void increaseProfileCount() {
+        this.profileCount++;
+    }
+
+    public void decreaseProfileCount() {
+        this.profileCount--;
     }
 
 }

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/group/GroupSizeConstants.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/group/GroupSizeConstants.java
@@ -1,5 +1,0 @@
-package me.kong.groupservice.domain.entity.group;
-
-public final class GroupSizeConstants {
-    public static final int BASIC = 10;
-}

--- a/group-service/src/main/java/me/kong/groupservice/mapper/GroupMapper.java
+++ b/group-service/src/main/java/me/kong/groupservice/mapper/GroupMapper.java
@@ -3,9 +3,9 @@ package me.kong.groupservice.mapper;
 
 import lombok.RequiredArgsConstructor;
 import me.kong.commonlibrary.util.JwtReader;
+import me.kong.groupservice.common.Constants;
 import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.group.Group;
-import me.kong.groupservice.domain.entity.group.GroupSizeConstants;
 import me.kong.groupservice.dto.request.SaveGroupRequestDto;
 import me.kong.groupservice.dto.response.GroupResponseDto;
 import org.springframework.stereotype.Component;
@@ -20,7 +20,7 @@ public class GroupMapper {
         return Group.builder()
                 .name(dto.getGroupName())
                 .description(dto.getDescription())
-                .groupSize(GroupSizeConstants.BASIC)
+                .groupSize(Constants.BASIC)
                 .joinCondition(dto.getJoinCondition())
                 .groupScope(dto.getGroupScope())
                 .state(State.GENERAL)

--- a/group-service/src/main/java/me/kong/groupservice/mapper/GroupMapper.java
+++ b/group-service/src/main/java/me/kong/groupservice/mapper/GroupMapper.java
@@ -25,6 +25,7 @@ public class GroupMapper {
                 .groupScope(dto.getGroupScope())
                 .state(State.GENERAL)
                 .ownerUserId(jwtReader.getUserId())
+                .profileCount(1)
                 .build();
     }
 

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupJoinFacade.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupJoinFacade.java
@@ -1,0 +1,101 @@
+package me.kong.groupservice.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
+import me.kong.commonlibrary.exception.common.DuplicateElementException;
+import me.kong.groupservice.common.exception.NoLoggedInProfileException;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.JoinResponse;
+import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.group.JoinCondition;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
+import me.kong.groupservice.domain.entity.profile.Profile;
+import me.kong.groupservice.dto.request.GroupJoinProcessDto;
+import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroupJoinFacade {
+
+    private final GroupJoinRequestService joinRequestService;
+    private final GroupService groupService;
+    private final ProfileService profileService;
+
+
+    @Transactional
+    public void joinGroup(GroupJoinRequestDto dto, Long groupId) {
+        Group group = groupService.findGroupById(groupId);
+
+        if (joinRequestService.pendingRequestExists(group.getId())) {
+            throw new DuplicateElementException("이미 가입 요청한 그룹입니다.");
+        }
+
+        try {
+            Profile profile = profileService.getLoggedInProfile(groupId);
+
+            switch (profile.getState()) {
+                case RESTRICTED -> {
+                    throw new UnAuthorizedException("추방당한 회원입니다. userId : " + profile.getUserId());
+                }
+                case GENERAL -> {
+                    throw new DuplicateElementException("이미 가입한 그룹입니다.");
+                }
+                case DELETED -> {
+                    if (group.getJoinCondition() == JoinCondition.OPEN) {
+                        groupService.checkGroupSize(group);
+                        group.increaseProfileCount();
+                        profile.setState(State.GENERAL);
+                    } else {
+                        joinRequestService.createNewGroupJoinRequest(dto, group);
+                    }
+                }
+            }
+        } catch (NoLoggedInProfileException e) {
+            if (group.getJoinCondition() == JoinCondition.OPEN) {
+                groupService.checkGroupSize(group);
+                group.increaseProfileCount();
+                profileService.createNewProfile(dto.getNickname(), GroupRole.MEMBER, group);
+            } else {
+                joinRequestService.createNewGroupJoinRequest(dto, group);
+            }
+        }
+    }
+
+    @Transactional
+    public void processGroupJoinRequest(Long requestId, GroupJoinProcessDto dto) {
+        GroupJoinRequest joinRequest = joinRequestService.getGroupJoinRequestByRequestId(requestId);
+
+        if (joinRequest.getResponse() != JoinResponse.PENDING) {
+            throw new DuplicateElementException("이미 처리된 가입 요청입니다. 요청 id : " + requestId);
+        }
+
+        profileService.checkLoggedInProfileIsGroupManager(joinRequest.getGroup().getId());
+
+        switch (dto.getAction()) {
+            case APPROVE -> {
+                Group group = joinRequest.getGroup();
+                groupService.checkGroupSize(group);
+                group.increaseProfileCount();
+
+                joinRequest.approveJoinRequest();
+                profileService.createNewProfile(joinRequest.getNickname(), GroupRole.MEMBER, joinRequest.getGroup());
+            }
+            case REJECT -> {
+                joinRequest.rejectJoinRequest();
+            }
+            default -> {
+                throw new IllegalArgumentException("지원하지 않는 처리 요청. action : " + dto.getAction());
+            }
+        }
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupJoinFacade.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupJoinFacade.java
@@ -3,23 +3,25 @@ package me.kong.groupservice.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
 import me.kong.commonlibrary.exception.common.DuplicateElementException;
+import me.kong.commonlibrary.util.JwtReader;
 import me.kong.groupservice.common.exception.NoLoggedInProfileException;
 import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
 import me.kong.groupservice.domain.entity.GroupJoinRequest.JoinResponse;
-import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.domain.entity.group.JoinCondition;
 import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.dto.request.GroupJoinProcessDto;
 import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.service.strategy.Consumers;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static me.kong.groupservice.common.Constants.*;
 
 
 @Slf4j
@@ -30,46 +32,9 @@ public class GroupJoinFacade {
     private final GroupJoinRequestService joinRequestService;
     private final GroupService groupService;
     private final ProfileService profileService;
+    private final Consumers consumers;
+    private final JwtReader jwtReader;
 
-
-    @Transactional
-    public void joinGroup(GroupJoinRequestDto dto, Long groupId) {
-        Group group = groupService.findGroupById(groupId);
-
-        if (joinRequestService.pendingRequestExists(group.getId())) {
-            throw new DuplicateElementException("이미 가입 요청한 그룹입니다.");
-        }
-
-        try {
-            Profile profile = profileService.getLoggedInProfile(groupId);
-
-            switch (profile.getState()) {
-                case RESTRICTED -> {
-                    throw new UnAuthorizedException("추방당한 회원입니다. userId : " + profile.getUserId());
-                }
-                case GENERAL -> {
-                    throw new DuplicateElementException("이미 가입한 그룹입니다.");
-                }
-                case DELETED -> {
-                    if (group.getJoinCondition() == JoinCondition.OPEN) {
-                        groupService.checkGroupSize(group);
-                        group.increaseProfileCount();
-                        profile.setState(State.GENERAL);
-                    } else {
-                        joinRequestService.createNewGroupJoinRequest(dto, group);
-                    }
-                }
-            }
-        } catch (NoLoggedInProfileException e) {
-            if (group.getJoinCondition() == JoinCondition.OPEN) {
-                groupService.checkGroupSize(group);
-                group.increaseProfileCount();
-                profileService.createNewProfile(dto.getNickname(), GroupRole.MEMBER, group);
-            } else {
-                joinRequestService.createNewGroupJoinRequest(dto, group);
-            }
-        }
-    }
 
     @Transactional
     public void processGroupJoinRequest(Long requestId, GroupJoinProcessDto dto) {
@@ -81,21 +46,45 @@ public class GroupJoinFacade {
 
         profileService.checkLoggedInProfileIsGroupManager(joinRequest.getGroup().getId());
 
-        switch (dto.getAction()) {
-            case APPROVE -> {
-                Group group = joinRequest.getGroup();
-                groupService.checkGroupSize(group);
-                group.increaseProfileCount();
-
-                joinRequest.approveJoinRequest();
-                profileService.createNewProfile(joinRequest.getNickname(), GroupRole.MEMBER, joinRequest.getGroup());
-            }
-            case REJECT -> {
-                joinRequest.rejectJoinRequest();
-            }
-            default -> {
-                throw new IllegalArgumentException("지원하지 않는 처리 요청. action : " + dto.getAction());
-            }
+        Consumer<GroupJoinRequest> joinRequestConsumer = consumers.getJoinRequestConsumer(dto.getAction());
+        if (joinRequestConsumer != null) {
+            joinRequestConsumer.accept(joinRequest);
+        } else {
+            log.warn(NoStateExceptionMessage, "가입 요청 처리", dto.getAction());
+            throw new IllegalStateException("No action found for state: " + dto.getAction());
         }
     }
+
+
+    @Transactional
+    public void joinGroup(GroupJoinRequestDto dto, Long groupId) {
+        Group group = groupService.findGroupById(groupId);
+        if (joinRequestService.pendingRequestExists(group.getId())) {
+            throw new DuplicateElementException("이미 가입 요청한 그룹입니다.");
+        }
+
+        try {
+            Profile profile = profileService.getLoggedInProfile(groupId);
+            BiConsumer<Profile, GroupJoinRequestDto> action = consumers.getGroupJoinConsumer(profile.getState());
+            if (action != null) {
+                action.accept(profile, dto);
+            } else {
+                log.warn(NoStateExceptionMessage, "그룹 가입", profile.getState());
+                throw new IllegalStateException("No action found : " + profile.getState());
+            }
+        } catch (NoLoggedInProfileException e) {
+            firstJoinProcess(dto, group);
+        }
+    }
+
+    private void firstJoinProcess(GroupJoinRequestDto dto, Group group) {
+        if (group.getJoinCondition() == JoinCondition.OPEN) {
+            groupService.checkGroupSize(group);
+            group.increaseProfileCount();
+            profileService.createNewProfile(dto.getNickname(), jwtReader.getUserId(), GroupRole.MEMBER, group);
+        } else {
+            joinRequestService.createNewGroupJoinRequest(dto, group);
+        }
+    }
+
 }

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupJoinRequestService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupJoinRequestService.java
@@ -1,14 +1,10 @@
 package me.kong.groupservice.service;
 
 import lombok.RequiredArgsConstructor;
-import me.kong.commonlibrary.exception.common.DuplicateElementException;
 import me.kong.commonlibrary.util.JwtReader;
 import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
-import me.kong.groupservice.domain.entity.GroupJoinRequest.JoinResponse;
 import me.kong.groupservice.domain.entity.group.Group;
-import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.repository.GroupJoinRequestRepository;
-import me.kong.groupservice.dto.request.GroupJoinProcessDto;
 import me.kong.groupservice.dto.request.GroupJoinRequestDto;
 import me.kong.groupservice.dto.request.enums.JoinRequestSearchCondition;
 import me.kong.groupservice.mapper.GroupJoinRequestMapper;
@@ -64,30 +60,5 @@ public class GroupJoinRequestService {
             }
         }
         return requests;
-    }
-
-    @Transactional
-    public void processGroupJoinRequest(Long requestId, GroupJoinProcessDto dto) {
-        GroupJoinRequest joinRequest = getGroupJoinRequestByRequestId(requestId);
-
-        if (joinRequest.getResponse() != JoinResponse.PENDING) {
-            throw new DuplicateElementException("이미 처리된 가입 요청입니다. 요청 id : " + requestId);
-        }
-
-        profileService.checkLoggedInProfileIsGroupManager(joinRequest.getGroup().getId());
-
-        switch (dto.getAction()) {
-            case APPROVE -> {
-                joinRequest.approveJoinRequest();
-                profileService.checkGroupSize(joinRequest.getGroup());
-                profileService.createNewProfile(joinRequest.getNickname(), GroupRole.MEMBER, joinRequest.getGroup());
-            }
-            case REJECT -> {
-                joinRequest.rejectJoinRequest();
-            }
-            default -> {
-                throw new IllegalArgumentException("지원하지 않는 처리 요청. action : " + dto.getAction());
-            }
-        }
     }
 }

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
 import me.kong.commonlibrary.exception.common.DuplicateElementException;
+import me.kong.groupservice.common.exception.GroupFullException;
 import me.kong.groupservice.common.exception.NoLoggedInProfileException;
 import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.group.JoinCondition;
@@ -18,6 +19,8 @@ import me.kong.groupservice.mapper.GroupMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.NoSuchElementException;
 
 @Slf4j
@@ -26,10 +29,8 @@ import java.util.NoSuchElementException;
 public class GroupService {
 
     private final GroupRepository groupRepository;
-    private final GroupJoinRequestService joinRequestService;
     private final ProfileService profileService;
     private final GroupMapper groupMapper;
-
 
     @Transactional
     public Group createNewGroup(SaveGroupRequestDto dto) {
@@ -40,46 +41,16 @@ public class GroupService {
         return group;
     }
 
-    @Transactional
-    public void joinGroup(GroupJoinRequestDto dto, Long groupId) {
-        Group group = findGroupById(groupId);
-
-        if (joinRequestService.pendingRequestExists(group.getId())) {
-            throw new DuplicateElementException("이미 가입 요청한 그룹입니다.");
-        }
-
-        try {
-            Profile profile = profileService.getLoggedInProfile(groupId);
-
-            switch (profile.getState()) {
-                case RESTRICTED -> {
-                    throw new UnAuthorizedException("추방당한 회원입니다. userId : " + profile.getUserId());
-                }
-                case GENERAL -> {
-                    throw new DuplicateElementException("이미 가입한 그룹입니다.");
-                }
-                case DELETED -> {
-                    if (group.getJoinCondition() == JoinCondition.OPEN) {
-                        profileService.checkGroupSize(group);
-                        profile.setState(State.GENERAL);
-                    } else {
-                        joinRequestService.createNewGroupJoinRequest(dto, group);
-                    }
-                }
-            }
-        } catch (NoLoggedInProfileException e) {
-            if (group.getJoinCondition() == JoinCondition.OPEN) {
-                profileService.checkGroupSize(group);
-                profileService.createNewProfile(dto.getNickname(), GroupRole.MEMBER, group);
-            } else {
-                joinRequestService.createNewGroupJoinRequest(dto, group);
-            }
-        }
-    }
-
     @Transactional(readOnly = true)
     public Group findGroupById(Long id) {
         return groupRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("찾으려는 그룹이 없습니다. id : " + id));
+    }
+
+    @Transactional(readOnly = true)
+    public void checkGroupSize(Group group) {
+        if (group.getProfileCount() >= group.getGroupSize()) {
+            throw new GroupFullException("최대 인원인 그룹입니다. id : " + group.getId());
+        }
     }
 }

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupService.java
@@ -3,24 +3,16 @@ package me.kong.groupservice.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
-import me.kong.commonlibrary.exception.common.DuplicateElementException;
+import me.kong.commonlibrary.util.JwtReader;
 import me.kong.groupservice.common.exception.GroupFullException;
-import me.kong.groupservice.common.exception.NoLoggedInProfileException;
-import me.kong.groupservice.domain.entity.State;
-import me.kong.groupservice.domain.entity.group.JoinCondition;
 import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.entity.group.Group;
-import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.domain.repository.GroupRepository;
-import me.kong.groupservice.dto.request.GroupJoinRequestDto;
 import me.kong.groupservice.dto.request.SaveGroupRequestDto;
 import me.kong.groupservice.mapper.GroupMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.NoSuchElementException;
 
 @Slf4j
@@ -31,12 +23,13 @@ public class GroupService {
     private final GroupRepository groupRepository;
     private final ProfileService profileService;
     private final GroupMapper groupMapper;
+    private final JwtReader jwtReader;
 
     @Transactional
     public Group createNewGroup(SaveGroupRequestDto dto) {
         Group group = groupRepository.save(groupMapper.toEntity(dto));
 
-        profileService.createNewProfile(dto.getNickname(), GroupRole.MANAGER, group);
+        profileService.createNewProfile(dto.getNickname(), jwtReader.getUserId(), GroupRole.MANAGER, group);
 
         return group;
     }

--- a/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
@@ -1,7 +1,6 @@
 package me.kong.groupservice.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
 import me.kong.commonlibrary.util.JwtReader;
 import me.kong.groupservice.common.exception.GroupFullException;
@@ -24,12 +23,12 @@ public class ProfileService {
     private final JwtReader jwtReader;
 
     @Transactional
-    public void createNewProfile(String nickname, GroupRole groupRole, Group group) {
+    public void createNewProfile(String nickname, Long userId, GroupRole groupRole, Group group) {
         Profile profile = Profile.builder()
                 .nickname(nickname)
                 .groupRole(groupRole)
                 .state(State.GENERAL)
-                .userId(jwtReader.getUserId()) // token에서 현재 로그인한 user의 id를 가져온다.
+                .userId(userId)
                 .group(group)
                 .build();
 

--- a/group-service/src/main/java/me/kong/groupservice/service/strategy/Consumers.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/strategy/Consumers.java
@@ -1,0 +1,84 @@
+package me.kong.groupservice.service.strategy;
+
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
+import me.kong.commonlibrary.exception.common.DuplicateElementException;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
+import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.group.JoinCondition;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
+import me.kong.groupservice.domain.entity.profile.Profile;
+import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.dto.request.enums.GroupJoinProcessAction;
+import me.kong.groupservice.service.GroupJoinRequestService;
+import me.kong.groupservice.service.GroupService;
+import me.kong.groupservice.service.ProfileService;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+@Component
+@RequiredArgsConstructor
+public class Consumers {
+
+    private final GroupService groupService;
+    private final GroupJoinRequestService joinRequestService;
+    private final ProfileService profileService;
+
+    private Map<State,BiConsumer<Profile, GroupJoinRequestDto>> groupJoinConsumerMap;
+    private Map<GroupJoinProcessAction, Consumer<GroupJoinRequest>> joinRequestConsumerMap;
+
+    public BiConsumer<Profile, GroupJoinRequestDto> getGroupJoinConsumer(State state) {
+        return groupJoinConsumerMap.get(state);
+    }
+
+    public Consumer<GroupJoinRequest> getJoinRequestConsumer(GroupJoinProcessAction action) {
+        return joinRequestConsumerMap.get(action);
+    }
+
+    @PostConstruct
+    public void initGroupJoinConsumerMap() {
+        groupJoinConsumerMap = new EnumMap<>(State.class);
+
+        groupJoinConsumerMap.put(State.RESTRICTED, (profile, dto) -> {
+            throw new UnAuthorizedException("추방당한 회원입니다. userId : " + profile.getUserId());
+        });
+
+        groupJoinConsumerMap.put(State.GENERAL, (profile, dto) -> {
+            throw new DuplicateElementException("이미 가입한 그룹입니다.");
+        });
+
+        groupJoinConsumerMap.put(State.DELETED, (profile, dto) -> {
+            Group group = profile.getGroup();
+            if (group.getJoinCondition() == JoinCondition.OPEN) {
+                groupService.checkGroupSize(group);
+                group.increaseProfileCount();
+                profile.setState(State.GENERAL);
+            } else {
+                joinRequestService.createNewGroupJoinRequest(dto, group);
+            }
+        });
+    }
+
+    @PostConstruct
+    public void initJoinRequestConsumerMap() {
+        joinRequestConsumerMap = new EnumMap<>(GroupJoinProcessAction.class);
+
+        joinRequestConsumerMap.put(GroupJoinProcessAction.APPROVE, joinRequest -> {
+            Group group = joinRequest.getGroup();
+            groupService.checkGroupSize(group);
+            group.increaseProfileCount();
+
+            joinRequest.approveJoinRequest();
+            profileService.createNewProfile(joinRequest.getNickname(), joinRequest.getUserId(), GroupRole.MEMBER, joinRequest.getGroup());
+        });
+
+        joinRequestConsumerMap.put(GroupJoinProcessAction.REJECT, GroupJoinRequest::rejectJoinRequest);
+    }
+}

--- a/group-service/src/test/java/me/kong/groupservice/integration/GroupManagementServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/integration/GroupManagementServiceTest.java
@@ -8,7 +8,6 @@ import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.repository.GroupRepository;
 import me.kong.groupservice.domain.repository.ProfileRepository;
 import me.kong.groupservice.dto.request.SaveGroupRequestDto;
-import me.kong.groupservice.service.GroupJoinRequestService;
 import me.kong.groupservice.service.GroupService;
 import me.kong.groupservice.service.ProfileService;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,9 +26,6 @@ public class GroupManagementServiceTest {
 
     @Autowired
     private GroupService groupService;
-
-    @Autowired
-    private GroupJoinRequestService joinRequestService;
 
     @MockBean
     private ProfileService profileService;
@@ -60,7 +56,7 @@ public class GroupManagementServiceTest {
                 .build();
 
         doThrow(new RuntimeException())
-                .when(profileService).createNewProfile(anyString(), any(GroupRole.class), any(Group.class));
+                .when(profileService).createNewProfile(anyString(), any(Long.class), any(GroupRole.class), any(Group.class));
 
         //when
         try {

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupJoinFacadeTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupJoinFacadeTest.java
@@ -1,0 +1,312 @@
+package me.kong.groupservice.service;
+
+import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
+import me.kong.commonlibrary.exception.common.DuplicateElementException;
+import me.kong.commonlibrary.util.JwtReader;
+import me.kong.groupservice.common.exception.NoLoggedInProfileException;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
+import me.kong.groupservice.domain.entity.GroupJoinRequest.JoinResponse;
+import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.group.GroupScope;
+import me.kong.groupservice.domain.entity.group.JoinCondition;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
+import me.kong.groupservice.domain.entity.profile.Profile;
+import me.kong.groupservice.dto.request.GroupJoinProcessDto;
+import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.dto.request.enums.GroupJoinProcessAction;
+import me.kong.groupservice.service.strategy.Consumers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupJoinFacadeTest {
+
+    @InjectMocks
+    GroupJoinFacade groupJoinFacade;
+
+    @Mock
+    GroupJoinRequestService joinRequestService;
+
+    @Mock
+    GroupService groupService;
+
+    @Mock
+    ProfileService profileService;
+
+    @Mock
+    Consumers consumers;
+
+    @Mock
+    JwtReader jwtReader;
+
+
+    Group group;
+    Profile profile;
+    GroupJoinRequest joinRequest;
+    GroupJoinRequestDto joinRequestDto;
+    GroupJoinProcessDto joinProcessDto;
+
+    Long userId = 1L;
+    Long groupId = 1L;
+    Long requestId = 1L;
+    String groupName = "groupName";
+    String desc = "desc";
+    String nickname = "nickname";
+    String requestInfo = "requestInfo";
+
+    @BeforeEach
+    void init() {
+        group = mock(Group.class);
+        profile = mock(Profile.class);
+    }
+
+    @Test
+    @DisplayName("대기중인 가입 요청이 있다면 예외가 발생한다")
+    void failToJoinByPendingRequestExist() {
+        //given
+        when(group.getId()).thenReturn(groupId);
+        when(groupService.findGroupById(groupId)).thenReturn(group);
+        when(joinRequestService.pendingRequestExists(groupId)).thenReturn(true);
+
+        //then
+        assertThrows(DuplicateElementException.class, () -> groupJoinFacade.joinGroup(joinRequestDto, groupId));
+    }
+
+    @Test
+    @DisplayName("OPEN 그룹에 새로 가입 요청 시 새로운 프로필이 등록된다")
+    void successToJoinOpenGroup() {
+        //given
+        firstJoinSetting(JoinCondition.OPEN);
+        when(jwtReader.getUserId()).thenReturn(userId);
+
+        //when
+        groupJoinFacade.joinGroup(joinRequestDto, groupId);
+
+        //then
+        verify(group, times(1)).increaseProfileCount();
+        verify(profileService)
+                .createNewProfile(joinRequestDto.getNickname(), userId, GroupRole.MEMBER, group);
+    }
+
+    @Test
+    @DisplayName("APPROVAL_REQUIRED 그룹에 새로 가입 요청 시 GroupJoinRequest가 생성된다")
+    void successToJoinApprovalRequired() {
+        //given
+        firstJoinSetting(JoinCondition.APPROVAL_REQUIRED);
+
+        //when
+        groupJoinFacade.joinGroup(joinRequestDto, groupId);
+
+        //then
+        verify(joinRequestService, times(1)).createNewGroupJoinRequest(joinRequestDto, group);
+    }
+
+    @Test
+    @DisplayName("OPEN 그룹 가입 시 탈퇴한 전적이 존재하면 이전 프로필을 되살린다")
+    void successToJoinWithPreviousProfile() {
+        //given
+        joinWithProfileSetting(State.DELETED, JoinCondition.OPEN);
+
+        //when
+        groupJoinFacade.joinGroup(joinRequestDto, groupId);
+
+        //then
+        assertEquals(profile.getState(), State.GENERAL);
+        verify(group, times(1)).increaseProfileCount();
+    }
+
+    @Test
+    @DisplayName("APPROVAL_REQUIRED 그룹에 탈퇴한 전적이 존재하면 GroupJoinRequest가 생성된다")
+    void successToJoinApprovalRequiredWithPreviousProfile() {
+        //given
+        joinWithProfileSetting(State.DELETED, JoinCondition.APPROVAL_REQUIRED);
+
+        //when
+        groupJoinFacade.joinGroup(joinRequestDto, groupId);
+
+        //then
+        verify(joinRequestService, times(1)).createNewGroupJoinRequest(joinRequestDto, group);
+    }
+
+    @Test
+    @DisplayName("추방당한 전적이 있다면 예외가 발생한다")
+    void failToJoinByPreviousBanRecord() {
+        //given
+        joinWithProfileSetting(State.RESTRICTED, JoinCondition.OPEN);
+
+        //then
+        assertThrows(UnAuthorizedException.class, () -> groupJoinFacade.joinGroup(joinRequestDto, groupId));
+    }
+
+    @Test
+    @DisplayName("이미 가입한 그룹에 요청 시 예외가 발생한다")
+    void failedByAlreadyJoinGroup() {
+        //given
+        joinWithProfileSetting(State.GENERAL, JoinCondition.OPEN);
+
+        //then
+        assertThrows(DuplicateElementException.class, () -> groupJoinFacade.joinGroup(joinRequestDto, groupId));
+    }
+
+
+    private void groupJoinConsumerSetting(State state, JoinCondition joinCondition) {
+        BiConsumer<Profile, GroupJoinRequestDto> restricted = (p, dto) -> {
+            throw new UnAuthorizedException("추방당한 회원입니다. userId : " + profile.getUserId());
+        };
+        BiConsumer<Profile, GroupJoinRequestDto> general = (p, dto) -> {
+            throw new DuplicateElementException("이미 가입한 그룹입니다.");
+        };
+        BiConsumer<Profile, GroupJoinRequestDto> deleted = (p, dto) -> {
+            Group group = p.getGroup();
+            if (group.getJoinCondition() == JoinCondition.OPEN) {
+                groupService.checkGroupSize(group);
+                group.increaseProfileCount();
+                p.setState(State.GENERAL);
+            } else {
+                joinRequestService.createNewGroupJoinRequest(dto, group);
+            }
+        };
+
+        if (state == State.DELETED) {
+            when(consumers.getGroupJoinConsumer(any(State.class))).thenReturn(deleted);
+            when(group.getJoinCondition()).thenReturn(joinCondition);
+        } else if (state == State.RESTRICTED) {
+            when(consumers.getGroupJoinConsumer(any(State.class))).thenReturn(restricted);
+        } else if (state == State.GENERAL) {
+            when(consumers.getGroupJoinConsumer(any(State.class))).thenReturn(general);
+        }
+    }
+
+    private void joinWithProfileSetting(State state, JoinCondition joinCondition) {
+        joinGroupSetting();
+        profile = makeProfile(GroupRole.MEMBER, state);
+        when(profileService.getLoggedInProfile(groupId)).thenReturn(profile);
+        groupJoinConsumerSetting(state, joinCondition);
+    }
+
+    private void firstJoinSetting(JoinCondition joinCondition) {
+        joinGroupSetting();
+        when(group.getJoinCondition()).thenReturn(joinCondition);
+        when(profileService.getLoggedInProfile(groupId)).thenThrow(NoLoggedInProfileException.class);
+    }
+
+    private void joinGroupSetting() {
+        joinRequestDto = makeJoinRequestDto();
+        when(group.getId()).thenReturn(groupId);
+        when(groupService.findGroupById(groupId)).thenReturn(group);
+        when(joinRequestService.pendingRequestExists(groupId)).thenReturn(false);
+    }
+
+
+
+    @Test
+    @DisplayName("가입 요청이 이미 처리되었다면 예외가 발생한다")
+    void failedByAlreadyProcessed() {
+        //given
+        processJoinRequestSetting(GroupJoinProcessAction.APPROVE, JoinResponse.APPROVED);
+
+        // then
+        assertThrows(DuplicateElementException.class,
+                () -> groupJoinFacade.processGroupJoinRequest(requestId, joinProcessDto));
+    }
+
+    @Test
+    @DisplayName("가입 승인 시, 가입 요청 상태가 승인으로 변경되고 새로운 프로필을 생성한다")
+    void successToApproveGroupJoinRequest() {
+        //given
+        processJoinRequestConsumerSetting(GroupJoinProcessAction.APPROVE);
+
+        // when
+        groupJoinFacade.processGroupJoinRequest(requestId, joinProcessDto);
+
+        // then
+        assertEquals(joinRequest.getResponse(), JoinResponse.APPROVED);
+        verify(profileService, times(1)).createNewProfile(nickname, userId, GroupRole.MEMBER, group);
+    }
+
+    @Test
+    @DisplayName("가입 거절 시, 가입 요청 상태가 거절로 변경된다")
+    void successToRejectGroupJoinRequest() {
+        //given
+        processJoinRequestConsumerSetting(GroupJoinProcessAction.REJECT);
+
+        //when
+        groupJoinFacade.processGroupJoinRequest(requestId, joinProcessDto);
+
+        //then
+        assertEquals(joinRequest.getResponse(), JoinResponse.REJECTED);
+    }
+
+
+    private void processJoinRequestConsumerSetting(GroupJoinProcessAction action) {
+        Consumer<GroupJoinRequest> approve = req -> {
+            Group group = req.getGroup();
+            groupService.checkGroupSize(group);
+            group.increaseProfileCount();
+
+            req.approveJoinRequest();
+            profileService.createNewProfile(req.getNickname(), req.getUserId(), GroupRole.MEMBER, req.getGroup());
+        };
+        Consumer<GroupJoinRequest> reject = GroupJoinRequest::rejectJoinRequest;
+
+        if (action == GroupJoinProcessAction.APPROVE) {
+            when(consumers.getJoinRequestConsumer(any(GroupJoinProcessAction.class))).thenReturn(approve);
+        } else if (action == GroupJoinProcessAction.REJECT) {
+            when(consumers.getJoinRequestConsumer(any(GroupJoinProcessAction.class))).thenReturn(reject);
+        }
+        processJoinRequestSetting(action, JoinResponse.PENDING);
+    }
+
+
+    private void processJoinRequestSetting(GroupJoinProcessAction action, JoinResponse joinResponse) {
+        joinProcessDto = makeProcessDto(action);
+        joinRequest = makeJoinRequest(joinResponse);
+        when(joinRequestService.getGroupJoinRequestByRequestId(requestId)).thenReturn(joinRequest);
+    }
+
+    private Profile makeProfile(GroupRole groupRole, State state) {
+        return Profile.builder()
+                .nickname(nickname)
+                .groupRole(groupRole)
+                .state(state)
+                .group(group)
+                .userId(userId)
+                .build();
+    }
+
+    private GroupJoinRequestDto makeJoinRequestDto() {
+        return GroupJoinRequestDto.builder()
+                .nickname(nickname)
+                .requestInfo(requestInfo)
+                .build();
+    }
+
+    private GroupJoinProcessDto makeProcessDto(GroupJoinProcessAction action) {
+        return GroupJoinProcessDto.builder()
+                .action(action)
+                .build();
+    }
+
+    private GroupJoinRequest makeJoinRequest(JoinResponse response) {
+        return GroupJoinRequest.builder()
+                .nickname(nickname)
+                .response(response)
+                .group(group)
+                .userId(userId)
+                .build();
+    }
+}

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupServiceTest.java
@@ -1,27 +1,17 @@
 package me.kong.groupservice.service;
 
-import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
-import me.kong.commonlibrary.exception.common.DuplicateElementException;
-import me.kong.groupservice.common.exception.NoLoggedInProfileException;
-import me.kong.groupservice.domain.entity.State;
+import me.kong.commonlibrary.util.JwtReader;
 import me.kong.groupservice.domain.entity.group.Group;
-import me.kong.groupservice.domain.entity.group.GroupScope;
-import me.kong.groupservice.domain.entity.group.JoinCondition;
 import me.kong.groupservice.domain.entity.profile.GroupRole;
-import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.domain.repository.GroupRepository;
-import me.kong.groupservice.dto.request.GroupJoinRequestDto;
 import me.kong.groupservice.dto.request.SaveGroupRequestDto;
 import me.kong.groupservice.mapper.GroupMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -37,47 +27,36 @@ class GroupServiceTest {
     GroupRepository groupRepository;
 
     @Mock
-    ProfileService profileService;
-
-    @Mock
-    GroupJoinRequestService joinRequestService;
-
-    @Mock
     GroupMapper groupMapper;
 
+    @Mock
+    JwtReader jwtReader;
+
+    @Mock
+    ProfileService profileService;
+
     SaveGroupRequestDto dto;
-    GroupJoinRequestDto joinRequestDto;
     Group group;
-    Profile profile;
-
-    String groupName;
-    String description;
-    String nickname;
-
-    @BeforeEach
-    void init() {
-        dto = mock(SaveGroupRequestDto.class);
-        joinRequestDto = GroupJoinRequestDto.builder()
-                .nickname("testUser")
-                .build();
-        group = mock(Group.class);
-        groupName = "test group";
-        description = "테스트 그룹입니다";
-        nickname = "testNickname";
-    }
 
     @Test
     @DisplayName("그룹 생성에 성공한다")
     void successToCreateNewGroup() {
         //given
+        dto = mock(SaveGroupRequestDto.class);
+        group = mock(Group.class);
+        when(dto.getNickname()).thenReturn("test");
+        when(jwtReader.getUserId()).thenReturn(1L);
         when(groupMapper.toEntity(any(SaveGroupRequestDto.class))).thenReturn(group);
+        when(groupRepository.save(any(Group.class))).thenReturn(group);
+
 
         //when
         groupService.createNewGroup(dto);
 
         //then
         verify(groupRepository, times(1)).save(any(Group.class));
-        verify(groupMapper, times(1)).toEntity(any(SaveGroupRequestDto.class));
+        verify(profileService, times(1))
+                .createNewProfile(eq("test"), eq(1L), eq(GroupRole.MANAGER), eq(group));
     }
 
     @Test
@@ -88,124 +67,5 @@ class GroupServiceTest {
 
         //then
         assertThrows(RuntimeException.class, () -> groupService.createNewGroup(dto));
-    }
-
-
-    @Test
-    @DisplayName("OPEN 그룹에 새로 가입 요청 시 새로운 프로필이 등록된다")
-    void successToJoinOpenGroup() {
-        //given
-        group = makeGroup(JoinCondition.OPEN);
-
-        when(joinRequestService.pendingRequestExists(any())).thenReturn(false);
-        when(profileService.getLoggedInProfile(any())).thenThrow(NoLoggedInProfileException.class);
-        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
-
-        //when
-        groupService.joinGroup(joinRequestDto, any(Long.class));
-
-        //then
-        verify(profileService, times(1))
-                .createNewProfile(joinRequestDto.getNickname(), GroupRole.MEMBER, group);
-    }
-
-    @Test
-    @DisplayName("APPROVAL_REQUIRED 그룹에 새로 가입 요청 시 GroupJoinRequest가 생성된다")
-    void successToJoinApprovalRequired() {
-        //given
-        group = makeGroup(JoinCondition.APPROVAL_REQUIRED);
-
-        when(joinRequestService.pendingRequestExists(any())).thenReturn(false);
-        when(profileService.getLoggedInProfile(any())).thenThrow(NoLoggedInProfileException.class);
-        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
-
-        //when
-        groupService.joinGroup(joinRequestDto, any(Long.class));
-
-        //then
-        verify(joinRequestService, times(1))
-                .createNewGroupJoinRequest(any(GroupJoinRequestDto.class), any(Group.class));
-    }
-
-    @Test
-    @DisplayName("OPEN 그룹 가입 시 탈퇴한 전적이 존재하면 이전 프로필을 되살린다")
-    void successToJoinWithPreviousProfile() {
-        //given
-        group = makeGroup(JoinCondition.OPEN);
-        profile = makeProfile(GroupRole.MEMBER, State.DELETED);
-
-        when(joinRequestService.pendingRequestExists(any())).thenReturn(false);
-        when(profileService.getLoggedInProfile(any())).thenReturn(profile);
-        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
-
-        //when
-        groupService.joinGroup(joinRequestDto, any(Long.class));
-
-        //then
-        assertEquals(State.GENERAL, profile.getState());
-    }
-
-    @Test
-    @DisplayName("APPROVAL_REQUIRED 그룹에 탈퇴한 전적이 존재하면 GroupJoinRequest가 생성된다")
-    void successToJoinApprovalRequiredWithPreviousProfile() {
-        //given
-        group = makeGroup(JoinCondition.APPROVAL_REQUIRED);
-        profile = makeProfile(GroupRole.MEMBER, State.DELETED);
-
-        when(joinRequestService.pendingRequestExists(any())).thenReturn(false);
-        when(profileService.getLoggedInProfile(any())).thenReturn(profile);
-        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
-
-        //when
-        groupService.joinGroup(joinRequestDto, any(Long.class));
-
-        //then
-        verify(joinRequestService, times(1))
-                .createNewGroupJoinRequest(any(GroupJoinRequestDto.class), any(Group.class));
-    }
-
-    @Test
-    @DisplayName("대기중인 가입 요청이 있다면 DuplicateElementException이 발생한다")
-    void failToJoinByPendingRequestExist() {
-        //given
-        when(joinRequestService.pendingRequestExists(any())).thenReturn(true);
-        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
-
-        //then
-        assertThrows(DuplicateElementException.class, () -> groupService.joinGroup(joinRequestDto, any(Long.class)));
-    }
-
-    @Test
-    @DisplayName("추방당한 전적이 있다면 ForbiddenAccessException이 발생한다")
-    void failToJoinByPreviousBanRecord() {
-        //given
-        profile = makeProfile(GroupRole.MEMBER, State.RESTRICTED);
-        when(joinRequestService.pendingRequestExists(any())).thenReturn(false);
-        when(profileService.getLoggedInProfile(any())).thenReturn(profile);
-        when(groupRepository.findById(any())).thenReturn(Optional.of(group));
-
-        //then
-        assertThrows(UnAuthorizedException.class, () -> groupService.joinGroup(joinRequestDto, any(Long.class)));
-    }
-
-
-    private Group makeGroup(JoinCondition joinCondition) {
-        return Group.builder()
-                .name(groupName)
-                .description(description)
-                .groupScope(GroupScope.PUBLIC)
-                .joinCondition(joinCondition)
-                .ownerUserId(1L)
-                .build();
-    }
-
-    private Profile makeProfile(GroupRole groupRole, State state) {
-        return Profile.builder()
-                .nickname(nickname)
-                .groupRole(groupRole)
-                .state(state)
-                .group(group)
-                .userId(1L)
-                .build();
     }
 }

--- a/group-service/src/test/java/me/kong/groupservice/service/ProfileServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/ProfileServiceTest.java
@@ -5,7 +5,7 @@ import me.kong.commonlibrary.util.JwtReader;
 import me.kong.groupservice.common.exception.GroupFullException;
 import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.group.Group;
-import me.kong.groupservice.domain.entity.group.GroupSizeConstants;
+import me.kong.groupservice.common.Constants;
 import me.kong.groupservice.domain.entity.profile.GroupRole;
 import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.domain.repository.ProfileRepository;
@@ -38,10 +38,12 @@ class ProfileServiceTest {
     String nickname;
     GroupRole groupRole;
     Group group;
+    Long userId;
 
     @BeforeEach
     void init() {
         nickname = "testUser";
+        userId = 1L;
         groupRole = GroupRole.MANAGER;
         group = mock(Group.class);
     }
@@ -51,13 +53,11 @@ class ProfileServiceTest {
     @DisplayName("프로필 생성에 성공한다")
     void successToCreateNewProfile() {
         // Given
-        when(jwtReader.getUserId()).thenReturn(1L);
 
         //when
-        profileService.createNewProfile(nickname, groupRole, group);
+        profileService.createNewProfile(nickname, userId, groupRole, group);
 
         //then
-        verify(jwtReader, times(1)).getUserId();
         verify(profileRepository, times(1)).save(any(Profile.class));
     }
 
@@ -68,14 +68,13 @@ class ProfileServiceTest {
         when(profileRepository.save(any())).thenThrow(RuntimeException.class);
 
         //then
-        assertThrows(RuntimeException.class, () -> profileService.createNewProfile(nickname, groupRole, group));
+        assertThrows(RuntimeException.class, () -> profileService.createNewProfile(nickname, userId, groupRole, group));
     }
 
     @Test
     @DisplayName("그룹 매니저가 아닐 경우 예외가 발생한다")
     void unAuthorizeOccurred() {
         //given
-        Long userId = 1L;
         Long groupId = 1L;
         Profile profile = Profile.builder()
                 .groupRole(GroupRole.MEMBER)
@@ -92,9 +91,9 @@ class ProfileServiceTest {
     void isNotFullGroup() {
         //given
         Long groupId = 1L;
-        when(profileRepository.countByGroupIdAndState(groupId, State.GENERAL)).thenReturn(GroupSizeConstants.BASIC-1);
+        when(profileRepository.countByGroupIdAndState(groupId, State.GENERAL)).thenReturn(Constants.BASIC-1);
         when(group.getId()).thenReturn(groupId);
-        when(group.getGroupSize()).thenReturn(GroupSizeConstants.BASIC);
+        when(group.getGroupSize()).thenReturn(Constants.BASIC);
 
         //when
         profileService.checkGroupSize(group);
@@ -108,9 +107,9 @@ class ProfileServiceTest {
     void isFullGroupThrowsException() {
         //given
         Long groupId = 1L;
-        when(profileRepository.countByGroupIdAndState(groupId, State.GENERAL)).thenReturn(GroupSizeConstants.BASIC);
+        when(profileRepository.countByGroupIdAndState(groupId, State.GENERAL)).thenReturn(Constants.BASIC);
         when(group.getId()).thenReturn(groupId);
-        when(group.getGroupSize()).thenReturn(GroupSizeConstants.BASIC);
+        when(group.getGroupSize()).thenReturn(Constants.BASIC);
 
         //then
         assertThrows(GroupFullException.class, () -> profileService.checkGroupSize(group));


### PR DESCRIPTION
## 구현 기능
#### 그룹 엔티티에 profile_count 필드 추가 및 그룹 정원 확인 로직 변경
- 기존 : 해당 그룹의 활성화된 프로필 개수 조회
- 변경 : 그룹 테이블의 profile_count 조회
- 사유: 가입된 프로필이 늘어날수록 부담되는 조회 작업을 개선하기 위함

## 개선 기능
#### 퍼사드 패턴 도입
- 그룹 가입 로직이 GroupService와 GroupJoinRequestService에 분산 -> 복잡한 의존 관계 형성
- 두 서비스 간 순환 의존 문제가 발생
- **해결: Facade 패턴을 도입하여 의존 문제를 해결하고, 코드 구조를 개선**
#### switch 구문 리팩토링
- 비즈니스 로직의 모든 분기를 service 로직에서 처리 -> 가독성 하락 및 코드 변경에 취약
- **해결: Consumer를 도입하여 책임을 분리하고, 코드 가독성과 유지보수성을 향상**