### PR TITLE
[#30] 동시성 이슈 해결

### DIFF
--- a/group-service/.gitignore
+++ b/group-service/.gitignore
@@ -37,4 +37,8 @@ out/
 .vscode/
 
 ### ETC ###
-application.*
+application.properties
+
+application-db.yml
+application-local.yml
+application-redis.yml

--- a/group-service/build.gradle
+++ b/group-service/build.gradle
@@ -27,16 +27,23 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.31.0'
+
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
     implementation 'me.kong:common-library:0.0.2-SNAPSHOT'
 }
 

--- a/group-service/src/main/java/me/kong/groupservice/common/annotation/RedisLock.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/annotation/RedisLock.java
@@ -1,0 +1,20 @@
+package me.kong.groupservice.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RedisLock {
+
+    String key();
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    long waitTime() default 5L;
+
+    long leaseTime() default 3L;
+}

--- a/group-service/src/main/java/me/kong/groupservice/common/aop/AopForTransaction.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/aop/AopForTransaction.java
@@ -1,0 +1,16 @@
+package me.kong.groupservice.common.aop;
+
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(ProceedingJoinPoint pjp) throws Throwable {
+        return pjp.proceed();
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/common/aop/RedisLockAop.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/aop/RedisLockAop.java
@@ -1,0 +1,55 @@
+package me.kong.groupservice.common.aop;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.kong.groupservice.common.annotation.RedisLock;
+import me.kong.groupservice.common.util.CustomSpringELParser;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@RequiredArgsConstructor
+@Aspect
+@Component
+public class RedisLockAop {
+    private static final String REDIS_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(me.kong.groupservice.common.annotation.RedisLock)")
+    public Object lock(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        RedisLock redisLock = method.getAnnotation(RedisLock.class);
+
+        String key = REDIS_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(
+                signature.getParameterNames(), joinPoint.getArgs(), redisLock.key());
+
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            boolean available = rLock.tryLock(redisLock.waitTime(), redisLock.leaseTime(), redisLock.timeUnit());
+            if (!available) {
+                return false;
+            }
+            return aopForTransaction.proceed(joinPoint);
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            try {
+                rLock.unlock();
+            } catch (IllegalMonitorStateException e) {
+                log.info("이미 반납된 락 : {}", key);
+            }
+        }
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/common/config/RedissonConfig.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/config/RedissonConfig.java
@@ -1,0 +1,30 @@
+package me.kong.groupservice.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        log.info("Connecting to Redis at {}:{} ", redisHost, redisPort);
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/common/util/CustomSpringELParser.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/util/CustomSpringELParser.java
@@ -1,0 +1,19 @@
+package me.kong.groupservice.common.util;
+
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i=0;i<parameterNames.length;i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
@@ -63,7 +63,7 @@ public class GroupController {
     public ResponseEntity<HttpStatus> handleGroupJoinRequest(@PathVariable Long groupId,
                                                              @PathVariable Long requestId,
                                                              @RequestBody GroupJoinProcessDto processDto) {
-        groupJoinFacade.processGroupJoinRequest(requestId, processDto);
+        groupJoinFacade.processGroupJoinRequest(groupId, requestId, processDto);
 
         return RESPONSE_OK;
     }

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupJoinFacade.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupJoinFacade.java
@@ -75,11 +75,6 @@ public class GroupJoinFacade {
         } catch (NoLoggedInProfileException e) {
             firstJoinProcess(dto, group);
         }
-        try {
-            Thread.sleep(3000);
-        } catch (InterruptedException e) {
-            // 동시성
-        }
     }
 
     private void firstJoinProcess(GroupJoinRequestDto dto, Group group) {

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupJoinFacade.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupJoinFacade.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.kong.commonlibrary.exception.common.DuplicateElementException;
 import me.kong.commonlibrary.util.JwtReader;
+import me.kong.groupservice.common.annotation.RedisLock;
 import me.kong.groupservice.common.exception.NoLoggedInProfileException;
 import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
 import me.kong.groupservice.domain.entity.GroupJoinRequest.JoinResponse;
@@ -36,8 +37,8 @@ public class GroupJoinFacade {
     private final JwtReader jwtReader;
 
 
-    @Transactional
-    public void processGroupJoinRequest(Long requestId, GroupJoinProcessDto dto) {
+    @RedisLock(key = "'group:'.concat(#groupId)")
+    public void processGroupJoinRequest(Long groupId, Long requestId, GroupJoinProcessDto dto) {
         GroupJoinRequest joinRequest = joinRequestService.getGroupJoinRequestByRequestId(requestId);
 
         if (joinRequest.getResponse() != JoinResponse.PENDING) {
@@ -46,17 +47,16 @@ public class GroupJoinFacade {
 
         profileService.checkLoggedInProfileIsGroupManager(joinRequest.getGroup().getId());
 
-        Consumer<GroupJoinRequest> joinRequestConsumer = consumers.getJoinRequestConsumer(dto.getAction());
-        if (joinRequestConsumer != null) {
-            joinRequestConsumer.accept(joinRequest);
+        Consumer<GroupJoinRequest> action = consumers.getJoinRequestConsumer(dto.getAction());
+        if (action != null) {
+            action.accept(joinRequest);
         } else {
             log.warn(NoStateExceptionMessage, "가입 요청 처리", dto.getAction());
             throw new IllegalStateException("No action found for state: " + dto.getAction());
         }
     }
 
-
-    @Transactional
+    @RedisLock(key = "'group:'.concat(#groupId)")
     public void joinGroup(GroupJoinRequestDto dto, Long groupId) {
         Group group = groupService.findGroupById(groupId);
         if (joinRequestService.pendingRequestExists(group.getId())) {
@@ -74,6 +74,11 @@ public class GroupJoinFacade {
             }
         } catch (NoLoggedInProfileException e) {
             firstJoinProcess(dto, group);
+        }
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            // 동시성
         }
     }
 

--- a/group-service/src/main/resources/application.yml
+++ b/group-service/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+server:
+  port: 8082
+
+spring:
+  application:
+    name: group-service
+
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        ddl-auto: none
+
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+
+  profiles:
+    include: db, route, redis

--- a/group-service/src/test/java/me/kong/groupservice/integration/GroupJoinServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/integration/GroupJoinServiceTest.java
@@ -1,0 +1,97 @@
+package me.kong.groupservice.integration;
+
+
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.group.GroupScope;
+import me.kong.groupservice.domain.entity.group.JoinCondition;
+import me.kong.groupservice.domain.repository.GroupRepository;
+import me.kong.groupservice.domain.repository.ProfileRepository;
+import me.kong.groupservice.dto.request.GroupJoinRequestDto;
+import me.kong.groupservice.dto.request.SaveGroupRequestDto;
+import me.kong.groupservice.service.GroupJoinFacade;
+import me.kong.groupservice.service.GroupService;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class GroupJoinServiceTest {
+    @Autowired
+    private GroupService groupService;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private ProfileRepository profileRepository;
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @Autowired
+    private GroupJoinFacade groupJoinFacade;
+
+    @BeforeEach
+    public void setUp() {
+        groupRepository.deleteAll();
+
+        // 테스트에 필요한 데이터 초기화
+        SaveGroupRequestDto saveGroupRequestDto = SaveGroupRequestDto.builder()
+                .groupName("test")
+                .joinCondition(JoinCondition.OPEN)
+                .groupScope(GroupScope.PUBLIC)
+                .nickname("testuser")
+                .description("desc")
+                .build();
+        groupService.createNewGroup(saveGroupRequestDto);
+    }
+
+    @Test
+    public void testConcurrentGroupJoin() throws InterruptedException {
+        int numberOfThreads = 10;
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        Group g = groupRepository.findAll().getFirst();
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            final int index = i;
+            String nickname = "joinTest" + i;
+            executorService.execute(() -> {
+                try {
+
+                    GroupJoinRequestDto dto = GroupJoinRequestDto.builder()
+                            .nickname(nickname)
+                            .requestInfo("info")
+                            .build();
+                    groupJoinFacade.joinGroup(dto, g.getId());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    // 그룹에 성공적으로 가입된 인원의 수를 확인
+                    Group group = groupRepository.findById(1L).orElseThrow();
+                    assertThat(group.getProfileCount()).isEqualTo(1);
+                });
+    }
+}

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupJoinFacadeTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupJoinFacadeTest.java
@@ -221,7 +221,7 @@ class GroupJoinFacadeTest {
 
         // then
         assertThrows(DuplicateElementException.class,
-                () -> groupJoinFacade.processGroupJoinRequest(requestId, joinProcessDto));
+                () -> groupJoinFacade.processGroupJoinRequest(groupId, requestId, joinProcessDto));
     }
 
     @Test
@@ -231,7 +231,7 @@ class GroupJoinFacadeTest {
         processJoinRequestConsumerSetting(GroupJoinProcessAction.APPROVE);
 
         // when
-        groupJoinFacade.processGroupJoinRequest(requestId, joinProcessDto);
+        groupJoinFacade.processGroupJoinRequest(groupId, requestId, joinProcessDto);
 
         // then
         assertEquals(joinRequest.getResponse(), JoinResponse.APPROVED);
@@ -245,7 +245,7 @@ class GroupJoinFacadeTest {
         processJoinRequestConsumerSetting(GroupJoinProcessAction.REJECT);
 
         //when
-        groupJoinFacade.processGroupJoinRequest(requestId, joinProcessDto);
+        groupJoinFacade.processGroupJoinRequest(groupId, requestId, joinProcessDto);
 
         //then
         assertEquals(joinRequest.getResponse(), JoinResponse.REJECTED);


### PR DESCRIPTION
## 발생 이슈
[그룹 가입 시 동시성 이슈 발생](https://github.com/f-lab-edu/music-everywhere/issues/30)

## 해결 내용
### Redis의 분산 락 적용
- redis, redisson 구현체를 사용하여 분산 락 적용, 동시성 문제 해결

## 해결 과정
### synchronized 사용
- synchronized method를 통해 동시성 문제 해결
- scale-out 등과 같이 여러 WAS가 존재하는 상황은 해결 불가
[synchronized 적용과 트러블슈팅](https://velog.io/@hyeok-kong/%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C%EC%99%80-synchronized)

### 배타적 락 사용
- DB level에서 제공하는 **비관적 락** 중 **배타적 락** 사용
- 레코드를 잠구는 **레코드 락** 특성 상 어플리케이션 성능 및 데드락 발생 가능
[배타적 락 적용과 트러블슈팅](https://velog.io/@hyeok-kong/%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C%EC%99%80-DB-Lock)

### 분산 락 사용
- MySQL의 user-level-lock과 redis의 분산 락 중 **redis** 선택 (학습을 위함)
- 기본 구현체인 Lettuce가 아닌 **redisson** 사용
- **redisson**의 경우 **pub/sub** 방식으로 락을 획득하기에 **스핀 락** 방식의 **Lettuce** 보다 적은 부하 기대 가능