### PR TITLE
[#36] JwtReader 서비스 계층에서 추출

### DIFF
--- a/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
@@ -4,6 +4,7 @@ package me.kong.groupservice.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.kong.commonlibrary.util.JwtReader;
 import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.dto.request.GroupJoinProcessDto;
 import me.kong.groupservice.dto.request.GroupJoinRequestDto;
@@ -35,17 +36,18 @@ public class GroupController {
     private final GroupMapper groupMapper;
     private final GroupJoinRequestMapper requestMapper;
     private final GroupJoinFacade groupJoinFacade;
+    private final JwtReader jwtReader;
 
     @PostMapping
     public ResponseEntity<GroupResponseDto> addGroup(@RequestBody @Valid SaveGroupRequestDto dto) {
-        Group group = groupService.createNewGroup(dto);
+        Group group = groupService.createNewGroup(dto, jwtReader.getUserId());
 
         return ResponseEntity.ok(groupMapper.toDto(group));
     }
 
     @PostMapping("{groupId}")
     public ResponseEntity<HttpStatus> joinGroup(@PathVariable Long groupId, @RequestBody @Valid GroupJoinRequestDto dto) {
-        groupJoinFacade.joinGroup(dto, groupId);
+        groupJoinFacade.joinGroup(dto, jwtReader.getUserId(), groupId);
 
         return ResponseEntity.status(HttpStatus.OK).build();
     }
@@ -54,7 +56,9 @@ public class GroupController {
     public ResponseEntity<List<GroupJoinResponseDto>> getGroupRequests(
             @PathVariable Long groupId,
             @RequestParam(name = "status", defaultValue = "PENDING") JoinRequestSearchCondition condition) {
-        List<GroupJoinResponseDto> requests = requestMapper.toDtoList(joinRequestService.getGroupJoinRequestsByGroupIdAndCondition(groupId, condition));
+        List<GroupJoinResponseDto> requests =
+                requestMapper.toDtoList(joinRequestService
+                        .getGroupJoinRequestsByGroupIdAndCondition(jwtReader.getUserId(), groupId, condition));
 
         return new ResponseEntity<>(requests, HttpStatus.OK);
     }
@@ -63,7 +67,7 @@ public class GroupController {
     public ResponseEntity<HttpStatus> handleGroupJoinRequest(@PathVariable Long groupId,
                                                              @PathVariable Long requestId,
                                                              @RequestBody GroupJoinProcessDto processDto) {
-        groupJoinFacade.processGroupJoinRequest(groupId, requestId, processDto);
+        groupJoinFacade.processGroupJoinRequest(jwtReader.getUserId(), groupId, requestId, processDto);
 
         return RESPONSE_OK;
     }

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupJoinRequestService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupJoinRequestService.java
@@ -18,7 +18,6 @@ import java.util.NoSuchElementException;
 @RequiredArgsConstructor
 public class GroupJoinRequestService {
 
-    private final JwtReader jwtReader;
     private final GroupJoinRequestRepository joinRequestRepository;
     private final GroupJoinRequestMapper joinRequestMapper;
     private final ProfileService profileService;
@@ -30,8 +29,8 @@ public class GroupJoinRequestService {
     }
 
     @Transactional(readOnly = true)
-    public boolean pendingRequestExists(Long groupId) {
-        return joinRequestRepository.pendingRequestExists(jwtReader.getUserId(), groupId);
+    public boolean pendingRequestExists(Long userId, Long groupId) {
+        return joinRequestRepository.pendingRequestExists(userId, groupId);
     }
 
     @Transactional
@@ -40,10 +39,10 @@ public class GroupJoinRequestService {
     }
 
     @Transactional(readOnly = true)
-    public List<GroupJoinRequest> getGroupJoinRequestsByGroupIdAndCondition(Long groupId, JoinRequestSearchCondition condition) {
+    public List<GroupJoinRequest> getGroupJoinRequestsByGroupIdAndCondition(Long userId, Long groupId, JoinRequestSearchCondition condition) {
         List<GroupJoinRequest> requests;
 
-        profileService.checkLoggedInProfileIsGroupManager(groupId);
+        profileService.checkLoggedInProfileIsGroupManager(userId, groupId);
 
         switch (condition) {
             case PENDING -> {

--- a/group-service/src/main/java/me/kong/groupservice/service/GroupService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/GroupService.java
@@ -23,13 +23,12 @@ public class GroupService {
     private final GroupRepository groupRepository;
     private final ProfileService profileService;
     private final GroupMapper groupMapper;
-    private final JwtReader jwtReader;
 
     @Transactional
-    public Group createNewGroup(SaveGroupRequestDto dto) {
+    public Group createNewGroup(SaveGroupRequestDto dto, Long userId) {
         Group group = groupRepository.save(groupMapper.toEntity(dto));
 
-        profileService.createNewProfile(dto.getNickname(), jwtReader.getUserId(), GroupRole.MANAGER, group);
+        profileService.createNewProfile(dto.getNickname(), userId, GroupRole.MANAGER, group);
 
         return group;
     }

--- a/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/ProfileService.java
@@ -20,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProfileService {
 
     private final ProfileRepository profileRepository;
-    private final JwtReader jwtReader;
 
     @Transactional
     public void createNewProfile(String nickname, Long userId, GroupRole groupRole, Group group) {
@@ -36,15 +35,13 @@ public class ProfileService {
     }
 
     @Transactional(readOnly = true, noRollbackFor = NoLoggedInProfileException.class)
-    public Profile getLoggedInProfile(Long groupId) {
-        Long userId = jwtReader.getUserId();
-
+    public Profile getLoggedInProfile(Long userId, Long groupId) {
         return profileRepository.findByUserIdAndGroupId(userId, groupId).orElseThrow(NoLoggedInProfileException::new);
     }
 
     @Transactional(readOnly = true)
-    public void checkLoggedInProfileIsGroupManager(Long groupId) {
-        Profile profile = getLoggedInProfile(groupId);
+    public void checkLoggedInProfileIsGroupManager(Long userId, Long groupId) {
+        Profile profile = getLoggedInProfile(userId, groupId);
 
         if (profile.getGroupRole() != GroupRole.MANAGER) {
             throw new UnAuthorizedException("권한이 없습니다. groupId : "

--- a/group-service/src/test/java/me/kong/groupservice/integration/GroupManagementServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/integration/GroupManagementServiceTest.java
@@ -54,13 +54,13 @@ public class GroupManagementServiceTest {
                 .joinCondition(JoinCondition.OPEN)
                 .nickname("testUser")
                 .build();
-
+        Long userId = 1L;
         doThrow(new RuntimeException())
                 .when(profileService).createNewProfile(anyString(), any(Long.class), any(GroupRole.class), any(Group.class));
 
         //when
         try {
-            groupService.createNewGroup(dto);
+            groupService.createNewGroup(dto, userId);
         } catch (RuntimeException e) {
             // 예외 발생!!!
         }

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupJoinRequestServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupJoinRequestServiceTest.java
@@ -36,16 +36,15 @@ class GroupJoinRequestServiceTest {
     @Mock
     GroupJoinRequestMapper groupJoinRequestMapper;
 
-    @Mock
-    JwtReader jwtReader;
-
 
     GroupJoinRequest request;
     GroupJoinRequestDto dto;
-    Group group;
-    Long groupId;
+    Group group;;
     JoinRequestSearchCondition condition;
     GroupJoinProcessDto processDto;
+
+    Long userId = 1L;
+    Long groupId = 2L;
 
     @BeforeEach
     void init() {
@@ -55,7 +54,7 @@ class GroupJoinRequestServiceTest {
                 .requestInfo("sample")
                 .nickname("testuser")
                 .build();
-        groupId = 1L;
+
     }
 
     @Test
@@ -90,7 +89,7 @@ class GroupJoinRequestServiceTest {
         JoinRequestSearchCondition condition = JoinRequestSearchCondition.ALL;
 
         //when
-        groupJoinRequestService.getGroupJoinRequestsByGroupIdAndCondition(groupId, condition);
+        groupJoinRequestService.getGroupJoinRequestsByGroupIdAndCondition(userId, groupId, condition);
 
         //then
         verify(groupJoinRequestRepository, times(1)).findAllByGroupId(groupId);
@@ -103,7 +102,7 @@ class GroupJoinRequestServiceTest {
         condition = JoinRequestSearchCondition.PENDING;
 
         //when
-        groupJoinRequestService.getGroupJoinRequestsByGroupIdAndCondition(groupId, condition);
+        groupJoinRequestService.getGroupJoinRequestsByGroupIdAndCondition(userId, groupId, condition);
 
         //then
         verify(groupJoinRequestRepository, times(1))
@@ -117,7 +116,7 @@ class GroupJoinRequestServiceTest {
         condition = JoinRequestSearchCondition.PROCESSED;
 
         //when
-        groupJoinRequestService.getGroupJoinRequestsByGroupIdAndCondition(groupId, condition);
+        groupJoinRequestService.getGroupJoinRequestsByGroupIdAndCondition(userId, groupId, condition);
 
         //then
         verify(groupJoinRequestRepository, times(1))

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupServiceTest.java
@@ -30,13 +30,11 @@ class GroupServiceTest {
     GroupMapper groupMapper;
 
     @Mock
-    JwtReader jwtReader;
-
-    @Mock
     ProfileService profileService;
 
     SaveGroupRequestDto dto;
     Group group;
+    Long userId = 1L;
 
     @Test
     @DisplayName("그룹 생성에 성공한다")
@@ -45,13 +43,11 @@ class GroupServiceTest {
         dto = mock(SaveGroupRequestDto.class);
         group = mock(Group.class);
         when(dto.getNickname()).thenReturn("test");
-        when(jwtReader.getUserId()).thenReturn(1L);
         when(groupMapper.toEntity(any(SaveGroupRequestDto.class))).thenReturn(group);
         when(groupRepository.save(any(Group.class))).thenReturn(group);
 
-
         //when
-        groupService.createNewGroup(dto);
+        groupService.createNewGroup(dto, userId);
 
         //then
         verify(groupRepository, times(1)).save(any(Group.class));
@@ -66,6 +62,6 @@ class GroupServiceTest {
         when(groupRepository.save(any())).thenThrow(RuntimeException.class);
 
         //then
-        assertThrows(RuntimeException.class, () -> groupService.createNewGroup(dto));
+        assertThrows(RuntimeException.class, () -> groupService.createNewGroup(dto, userId));
     }
 }

--- a/group-service/src/test/java/me/kong/groupservice/service/ProfileServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/ProfileServiceTest.java
@@ -32,18 +32,14 @@ class ProfileServiceTest {
     @Mock
     ProfileRepository profileRepository;
 
-    @Mock
-    JwtReader jwtReader;
-
     String nickname;
     GroupRole groupRole;
     Group group;
-    Long userId;
+    Long userId = 1L;
 
     @BeforeEach
     void init() {
         nickname = "testUser";
-        userId = 1L;
         groupRole = GroupRole.MANAGER;
         group = mock(Group.class);
     }
@@ -79,11 +75,10 @@ class ProfileServiceTest {
         Profile profile = Profile.builder()
                 .groupRole(GroupRole.MEMBER)
                 .build();
-        when(jwtReader.getUserId()).thenReturn(userId);
         when(profileRepository.findByUserIdAndGroupId(userId, groupId)).thenReturn(Optional.of(profile));
 
         //then
-        assertThrows(UnAuthorizedException.class, () -> profileService.checkLoggedInProfileIsGroupManager(groupId));
+        assertThrows(UnAuthorizedException.class, () -> profileService.checkLoggedInProfileIsGroupManager(userId, groupId));
     }
 
     @Test


### PR DESCRIPTION
## 개발 내용
- Service 계층에서 사용하던 `JwtReader` 를 Controller 계층에서 사용하도록 변경
- 변경된 로직에 따른 단위 테스트 수정
- 그룹 가입 시 동시성 문제 테스트 코드 작성