### PR TITLE
[#33] 게시글 권한관리 추가

### DIFF
--- a/group-service/src/main/java/me/kong/groupservice/common/annotation/GroupId.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/annotation/GroupId.java
@@ -1,0 +1,11 @@
+package me.kong.groupservice.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GroupId {
+}

--- a/group-service/src/main/java/me/kong/groupservice/common/annotation/GroupOnly.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/annotation/GroupOnly.java
@@ -1,0 +1,15 @@
+package me.kong.groupservice.common.annotation;
+
+
+import me.kong.groupservice.domain.entity.profile.GroupRole;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GroupOnly {
+    GroupRole role();
+}

--- a/group-service/src/main/java/me/kong/groupservice/common/annotation/UserId.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/annotation/UserId.java
@@ -1,0 +1,12 @@
+package me.kong.groupservice.common.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+}

--- a/group-service/src/main/java/me/kong/groupservice/common/aop/AuthorizationAspect.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/aop/AuthorizationAspect.java
@@ -1,0 +1,98 @@
+package me.kong.groupservice.common.aop;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
+import me.kong.groupservice.common.annotation.GroupId;
+import me.kong.groupservice.common.annotation.GroupOnly;
+import me.kong.groupservice.common.annotation.UserId;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
+import me.kong.groupservice.domain.entity.profile.Profile;
+import me.kong.groupservice.service.AuthService;
+import me.kong.groupservice.service.ProfileService;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AuthorizationAspect {
+
+    private final AuthService authService;
+    private final ProfileService profileService;
+
+
+    /**
+     * 사용하는 메소드의 매개 변수에 @UserId와 @GroupId를 반드시 등록해야 합니다.
+     * @param joinPoint
+     * @return
+     * @throws Throwable
+     */
+    @Around("@annotation(me.kong.groupservice.common.annotation.GroupOnly)")
+    public Object checkGroupMember(ProceedingJoinPoint joinPoint) throws Throwable {
+        Method method = getMethodSignature(joinPoint);
+        MethodInfo methodInfo = getMethodInfo(joinPoint, method);
+        UserAndGroup userAndGroup = hasUserAndGroupAnnotation(methodInfo);
+        GroupOnly groupOnly = method.getAnnotation(GroupOnly.class);
+
+        GroupRole role = groupOnly.role();
+
+        Profile profile = profileService.getLoggedInProfile(userAndGroup.userId(), userAndGroup.groupId());
+
+        if (role == GroupRole.MEMBER) {
+            if (!authService.isGroupMember(profile.getGroup(), profile)) {
+                throw new UnAuthorizedException("그룹 멤버가 아닙니다.");
+            }
+        } else if (role == GroupRole.MANAGER) {
+            if (!authService.isGroupManager(profile.getGroup(), profile)) {
+                throw new UnAuthorizedException("그룹 매니저가 아닙니다.");
+            }
+        }
+
+        return joinPoint.proceed();
+    }
+
+    private static Method getMethodSignature(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        return signature.getMethod();
+    }
+
+    private static UserAndGroup hasUserAndGroupAnnotation(MethodInfo methodInfo) {
+        Long userId = null;
+        Long groupId = null;
+
+        for (int i = 0; i < methodInfo.parameterAnnotations().length; i++) {
+            for (Annotation annotation : methodInfo.parameterAnnotations()[i]) {
+                if (annotation instanceof UserId) {
+                    userId = (Long) methodInfo.args()[i];
+                } else if (annotation instanceof GroupId) {
+                    groupId = (Long) methodInfo.args()[i];
+                }
+            }
+        }
+        if (userId == null || groupId == null) {
+            throw new IllegalArgumentException("@UserId, @GroupId 어노테이션이 없습니다.");
+        }
+        return new UserAndGroup(userId, groupId);
+    }
+
+    private static MethodInfo getMethodInfo(ProceedingJoinPoint joinPoint, Method method) {
+        Object[] args = joinPoint.getArgs();
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        return new MethodInfo(args, parameterAnnotations);
+    }
+
+    private record UserAndGroup(Long userId, Long groupId) {
+    }
+
+    private record MethodInfo(Object[] args, Annotation[][] parameterAnnotations) {
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/controller/PostController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/PostController.java
@@ -2,6 +2,7 @@ package me.kong.groupservice.controller;
 
 
 import lombok.RequiredArgsConstructor;
+import me.kong.commonlibrary.util.JwtReader;
 import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.dto.request.SavePostRequestDto;
@@ -24,18 +25,19 @@ public class PostController {
     private final PostService postService;
     private final PostMapper postMapper;
     private final ProfileService profileService;
+    private final JwtReader jwtReader;
 
     @PostMapping
     public ResponseEntity<HttpStatus> createNewPost(@PathVariable Long groupId,
                                                     @RequestBody SavePostRequestDto dto) {
-        postService.savePost(dto, groupId);
+        postService.savePost(dto, jwtReader.getUserId(), groupId);
         return RESPONSE_OK;
     }
 
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponseDto> getPost(@PathVariable Long groupId,
                                                    @PathVariable Long postId) {
-        Profile profile = profileService.getLoggedInProfile(groupId);
+        Profile profile = profileService.getLoggedInProfile(jwtReader.getUserId(), groupId);
         Post post = postService.findPost(postId);
 
         return new ResponseEntity<>(postMapper.toDto(post, profile), HttpStatus.OK);
@@ -44,7 +46,7 @@ public class PostController {
     @DeleteMapping("/{postId}")
     public ResponseEntity<HttpStatus> deletePost(@PathVariable Long groupId,
                                                    @PathVariable Long postId) {
-        postService.deletePost(postId);
+        postService.deletePost(postId, jwtReader.getUserId(), groupId);
         return RESPONSE_OK;
     }
 }

--- a/group-service/src/main/java/me/kong/groupservice/service/AuthService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/AuthService.java
@@ -1,0 +1,23 @@
+package me.kong.groupservice.service;
+
+import lombok.RequiredArgsConstructor;
+import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.profile.GroupRole;
+import me.kong.groupservice.domain.entity.profile.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    public boolean isGroupMember(Group group, Profile profile) {
+        return profile.getGroup().getId().equals(group.getId())
+                && profile.getState() != State.GENERAL;
+    }
+
+    public boolean isGroupManager(Group group, Profile profile) {
+        return isGroupMember(group, profile)
+                && profile.getGroupRole() == GroupRole.MANAGER;
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/service/PostService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/PostService.java
@@ -2,6 +2,10 @@ package me.kong.groupservice.service;
 
 
 import lombok.RequiredArgsConstructor;
+import me.kong.commonlibrary.exception.auth.UnAuthorizedException;
+import me.kong.groupservice.common.annotation.GroupId;
+import me.kong.groupservice.common.annotation.GroupOnly;
+import me.kong.groupservice.common.annotation.UserId;
 import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.domain.entity.profile.Profile;
@@ -13,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
 
+import static me.kong.groupservice.domain.entity.profile.GroupRole.*;
+
 @Service
 @RequiredArgsConstructor
 public class PostService {
@@ -21,23 +27,32 @@ public class PostService {
     private final PostMapper postMapper;
     private final ProfileService profileService;
 
+
+    @GroupOnly(role = MEMBER)
     @Transactional
-    public void savePost(SavePostRequestDto dto, Long groupId) {
-        Profile profile = profileService.getLoggedInProfile(groupId);
+    public void savePost(SavePostRequestDto dto, @UserId Long userId, @GroupId Long groupId) {
+        Profile profile = profileService.getLoggedInProfile(userId, groupId);
 
         Post post = postMapper.toEntity(dto, groupId, profile.getId());
 
         postRepository.save(post);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Post findPost(Long id) {
         return postRepository.findById(id)
+                .map(p -> {
+                    if (p.getState() != State.GENERAL) {
+                        throw new UnAuthorizedException("접근이 제한된 게시글입니다.");
+                    }
+                    return p;
+                })
                 .orElseThrow(() -> new NoSuchElementException("찾으려는 게시글이 없습니다. id : " + id));
     }
 
+    @GroupOnly(role = MANAGER)
     @Transactional
-    public void deletePost(Long id) {
+    public void deletePost(Long id, @UserId Long userId, @GroupId Long groupId) {
         Post post = findPost(id);
         post.setState(State.DELETED);
     }

--- a/group-service/src/test/java/me/kong/groupservice/service/PostServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/PostServiceTest.java
@@ -41,8 +41,9 @@ class PostServiceTest {
     Post post;
 
     Long profileId = 1L;
-    Long groupId = 1L;
-    Long postId = 1L;
+    Long groupId = 2L;
+    Long postId = 3L;
+    Long userId = 4L;
     String title = "테스트 제목";
     String content = "테스트 내용";
     PostScope scope = PostScope.GROUP_ONLY;
@@ -54,10 +55,10 @@ class PostServiceTest {
         savePostSetting(scope, State.GENERAL);
 
         //when
-        postService.savePost(savePostRequestDto, groupId);
+        postService.savePost(savePostRequestDto, userId, groupId);
 
         //then
-        verify(profileService, times(1)).getLoggedInProfile(groupId);
+        verify(profileService, times(1)).getLoggedInProfile(userId, groupId);
         verify(postMapper, times(1)).toEntity(savePostRequestDto, groupId, profileId);
         verify(postRepository, times(1)).save(post);
     }
@@ -69,7 +70,7 @@ class PostServiceTest {
         when(postRepository.save(any())).thenThrow(RuntimeException.class);
 
         //when & then
-        assertThrows(RuntimeException.class, () -> postService.savePost(savePostRequestDto, groupId));
+        assertThrows(RuntimeException.class, () -> postService.savePost(savePostRequestDto, userId, groupId));
     }
 
     @Test
@@ -101,7 +102,7 @@ class PostServiceTest {
         when(postRepository.findById(any(Long.class))).thenReturn(Optional.of(post));
 
         //when
-        postService.deletePost(postId);
+        postService.deletePost(postId, userId, groupId);
 
         //then
         assertEquals(State.DELETED, post.getState());
@@ -113,7 +114,7 @@ class PostServiceTest {
         when(profile.getId()).thenReturn(profileId);
         savePostRequestDto = makeSavePostRequestDto(scope);
         post = makePost(state);
-        when(profileService.getLoggedInProfile(groupId)).thenReturn(profile);
+        when(profileService.getLoggedInProfile(userId, groupId)).thenReturn(profile);
         when(postMapper.toEntity(savePostRequestDto, groupId, profile.getId())).thenReturn(post);
     }
 


### PR DESCRIPTION
## 구현 기능
- 게시글 등록, 삭제 메소드에 인가 추가
- AOP를 통해 구현

## 개발 코멘트
### 1. AOP를 통한 인가 구현
인가를 구현하며 선택에 대한 고민을 했습니다.
Spring Security 도입, 책임 연쇄 패턴 적용 등을 고민했지만 현재 수준에선 필요가 없다고 느꼈으며, AOP를 통해 구현하였습니다.
추후, 보다 복잡한 인가 로직이 요구될 때 위에서 언급한 방법들의 도입을 고려할 예정입니다.

### 2. AOP 구현 방식
AOP 구현에 다음 방식들을 고려했습니다.

1. 메소드 매개 변수의 순서를 맞추어 적용
>@Around("@annotation(CheckGroupMember) && args(userId, groupId, ..)")

위와 같은 방법을 사용할 시, 기존의 메소드들, 추후 개발될 메소드들을 모두 매개 변수 순서를 맞춰주어야 합니다.

2. 파라미터 어노테이션 적용
현재 적용한 방법입니다. 여전히 매개 변수를 강제하진 않지만, 위 방법보다 유연한 메소드 시그니처를 지원합니다.
