### PR TITLE
[#40] 로케일에 종속된 메세지 제거

### DIFF
--- a/group-service/src/test/java/me/kong/groupservice/validation/GroupJoinRequestValidationTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/validation/GroupJoinRequestValidationTest.java
@@ -49,7 +49,6 @@ public class GroupJoinRequestValidationTest {
         Set<ConstraintViolation<GroupJoinRequestDto>> violations = validator.validate(dto);
         ConstraintViolation<GroupJoinRequestDto> violation = violations.iterator().next();
         assertEquals("nickname", violation.getPropertyPath().toString());
-        assertEquals("비어 있을 수 없습니다", violation.getMessage());
     }
 
     @Test
@@ -73,6 +72,5 @@ public class GroupJoinRequestValidationTest {
         Set<ConstraintViolation<GroupJoinProcessDto>> violations = validator.validate(dto);
         ConstraintViolation<GroupJoinProcessDto> violation = violations.iterator().next();
         assertEquals("action", violation.getPropertyPath().toString());
-        assertEquals("널이어서는 안됩니다", violation.getMessage());
     }
 }

--- a/group-service/src/test/java/me/kong/groupservice/validation/GroupValidationTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/validation/GroupValidationTest.java
@@ -58,7 +58,6 @@ class GroupValidationTest {
 
         ConstraintViolation<SaveGroupRequestDto> violation = violations.iterator().next();
         assertEquals("groupName", violation.getPropertyPath().toString());
-        assertEquals("비어 있을 수 없습니다", violation.getMessage());
 
     }
 
@@ -79,7 +78,6 @@ class GroupValidationTest {
 
         ConstraintViolation<SaveGroupRequestDto> violation = violations.iterator().next();
         assertEquals("nickname", violation.getPropertyPath().toString());
-        assertEquals("비어 있을 수 없습니다", violation.getMessage());
     }
 
     @Test
@@ -99,7 +97,6 @@ class GroupValidationTest {
 
         ConstraintViolation<SaveGroupRequestDto> violation = violations.iterator().next();
         assertEquals("groupScope", violation.getPropertyPath().toString());
-        assertEquals("널이어서는 안됩니다", violation.getMessage());
     }
 
     @Test
@@ -119,7 +116,6 @@ class GroupValidationTest {
 
         ConstraintViolation<SaveGroupRequestDto> violation = violations.iterator().next();
         assertEquals("joinCondition", violation.getPropertyPath().toString());
-        assertEquals("널이어서는 안됩니다", violation.getMessage());
     }
 
 }


### PR DESCRIPTION
## 개발 내용
- 로케일에 종속된 메세지 테스트가 CI에 영향, 제거