### PR TITLE
[#48] 게시글 조회 API 구현

### DIFF
--- a/group-service/src/main/java/me/kong/groupservice/controller/PostController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/PostController.java
@@ -2,14 +2,18 @@ package me.kong.groupservice.controller;
 
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.kong.commonlibrary.util.JwtReader;
+import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.dto.request.SavePostRequestDto;
+import me.kong.groupservice.dto.response.PostListResponseDto;
 import me.kong.groupservice.dto.response.PostResponseDto;
 import me.kong.groupservice.mapper.PostMapper;
 import me.kong.groupservice.service.PostService;
 import me.kong.groupservice.service.ProfileService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 import static me.kong.commonlibrary.constant.HttpStatusResponseEntity.RESPONSE_OK;
 
 
+@Slf4j
 @RestController
 @RequestMapping("/api/groups/{groupId}/posts")
 @RequiredArgsConstructor
@@ -26,6 +31,18 @@ public class PostController {
     private final PostMapper postMapper;
     private final ProfileService profileService;
     private final JwtReader jwtReader;
+
+    @GetMapping
+    public ResponseEntity<Page<PostListResponseDto>> getPostList(
+            @PathVariable Long groupId,
+            @RequestParam(required = false, defaultValue = "GENERAL") State state,
+            @RequestParam(required = false , defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "10") int size) {
+
+        Page<Post> posts = postService.getRecentPosts(groupId, state, page, size);
+
+        return new ResponseEntity<>(postMapper.toDto(posts), HttpStatus.OK);
+    }
 
     @PostMapping
     public ResponseEntity<HttpStatus> createNewPost(@PathVariable Long groupId,

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/group/Group.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/group/Group.java
@@ -40,6 +40,8 @@ public class Group extends BaseTimeEntity {
     @Column(name = "profile_count")
     private Integer profileCount;
 
+
+
     @Builder
     public Group(String name, String description, Integer groupSize, JoinCondition joinCondition, GroupScope groupScope, State state, Long ownerUserId, Integer profileCount) {
         this.name = name;

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/group/Group.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/group/Group.java
@@ -11,7 +11,8 @@ import me.kong.groupservice.domain.entity.State;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "music_group")
+@Entity
+@Table(name = "music_group")
 public class Group extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/post/Post.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/post/Post.java
@@ -11,7 +11,8 @@ import me.kong.groupservice.domain.entity.profile.Profile;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "posts")
+@Entity
+@Table(name = "posts")
 public class Post extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,9 +31,11 @@ public class Post extends BaseTimeEntity {
     private State state;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
     private Group group;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id")
     private Profile profile;
 
     @Builder

--- a/group-service/src/main/java/me/kong/groupservice/domain/entity/post/Post.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/entity/post/Post.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import me.kong.commonlibrary.entity.BaseTimeEntity;
 import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.Group;
+import me.kong.groupservice.domain.entity.profile.Profile;
 
 
 @Getter
@@ -27,17 +29,19 @@ public class Post extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private State state;
 
-    private Long groupId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Group group;
 
-    private Long profileId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Profile profile;
 
     @Builder
-    public Post(String title, String content, PostScope postScope, State state, Long groupId, Long profileId) {
+    public Post(String title, String content, PostScope postScope, State state, Group group, Profile profile) {
         this.title = title;
         this.content = content;
         this.postScope = postScope;
         this.state = state;
-        this.groupId = groupId;
-        this.profileId = profileId;
+        this.group = group;
+        this.profile = profile;
     }
 }

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/PostRepository.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/PostRepository.java
@@ -1,10 +1,21 @@
 package me.kong.groupservice.domain.repository;
 
+import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.post.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Query("select p from Post p " +
+            " join fetch p.group g" +
+            " join fetch p.profile pf" +
+            " where p.state = :state and g.id = :groupId")
+    Page<Post> findRecentPost(@Param("groupId") Long groupId, @Param("state") State state, Pageable pageable);
 }

--- a/group-service/src/main/java/me/kong/groupservice/dto/response/PostListResponseDto.java
+++ b/group-service/src/main/java/me/kong/groupservice/dto/response/PostListResponseDto.java
@@ -1,0 +1,19 @@
+package me.kong.groupservice.dto.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PostListResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private Long groupId;
+    private Long profileId;
+    private String nickname;
+    private LocalDateTime updatedDate;
+}

--- a/group-service/src/main/java/me/kong/groupservice/mapper/PostMapper.java
+++ b/group-service/src/main/java/me/kong/groupservice/mapper/PostMapper.java
@@ -5,7 +5,9 @@ import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.dto.request.SavePostRequestDto;
+import me.kong.groupservice.dto.response.PostListResponseDto;
 import me.kong.groupservice.dto.response.PostResponseDto;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 
@@ -33,5 +35,17 @@ public class PostMapper {
                 .groupId(post.getGroup().getId())
                 .updatedDate(post.getUpdatedDate())
                 .build();
+    }
+
+    public Page<PostListResponseDto> toDto(Page<Post> posts) {
+        return posts.map(p -> PostListResponseDto.builder()
+                .id(p.getId())
+                .title(p.getTitle())
+                .content(p.getContent())
+                .groupId(p.getGroup().getId())
+                .profileId(p.getProfile().getId())
+                .nickname(p.getProfile().getNickname())
+                .updatedDate(p.getUpdatedDate())
+                .build());
     }
 }

--- a/group-service/src/main/java/me/kong/groupservice/mapper/PostMapper.java
+++ b/group-service/src/main/java/me/kong/groupservice/mapper/PostMapper.java
@@ -1,6 +1,7 @@
 package me.kong.groupservice.mapper;
 
 import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.dto.request.SavePostRequestDto;
@@ -11,14 +12,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class PostMapper {
 
-    public Post toEntity(SavePostRequestDto dto, Long groupId, Long profileId) {
+    public Post toEntity(SavePostRequestDto dto, Group group, Profile profile) {
         return Post.builder()
                 .title(dto.getTitle())
                 .content(dto.getContent())
                 .postScope(dto.getScope())
                 .state(State.GENERAL)
-                .groupId(groupId)
-                .profileId(profileId)
+                .group(group)
+                .profile(profile)
                 .build();
     }
 
@@ -29,7 +30,7 @@ public class PostMapper {
                 .content(post.getContent())
                 .nickname(profile.getNickname())
                 .profileId(profile.getId())
-                .groupId(post.getGroupId())
+                .groupId(post.getGroup().getId())
                 .updatedDate(post.getUpdatedDate())
                 .build();
     }

--- a/group-service/src/main/java/me/kong/groupservice/service/AuthService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/AuthService.java
@@ -13,7 +13,7 @@ public class AuthService {
 
     public boolean isGroupMember(Group group, Profile profile) {
         return profile.getGroup().getId().equals(group.getId())
-                && profile.getState() != State.GENERAL;
+                && profile.getState() == State.GENERAL;
     }
 
     public boolean isGroupManager(Group group, Profile profile) {

--- a/group-service/src/main/java/me/kong/groupservice/service/PostService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/PostService.java
@@ -7,8 +7,10 @@ import me.kong.groupservice.common.annotation.GroupId;
 import me.kong.groupservice.common.annotation.GroupOnly;
 import me.kong.groupservice.common.annotation.UserId;
 import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.domain.entity.profile.Profile;
+import me.kong.groupservice.domain.repository.GroupRepository;
 import me.kong.groupservice.domain.repository.PostRepository;
 import me.kong.groupservice.dto.request.SavePostRequestDto;
 import me.kong.groupservice.mapper.PostMapper;
@@ -26,14 +28,16 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostMapper postMapper;
     private final ProfileService profileService;
+    private final GroupService groupService;
 
 
     @GroupOnly(role = MEMBER)
     @Transactional
     public void savePost(SavePostRequestDto dto, @UserId Long userId, @GroupId Long groupId) {
+        Group group = groupService.findGroupById(groupId);
         Profile profile = profileService.getLoggedInProfile(userId, groupId);
 
-        Post post = postMapper.toEntity(dto, groupId, profile.getId());
+        Post post = postMapper.toEntity(dto, group, profile);
 
         postRepository.save(post);
     }

--- a/group-service/src/main/java/me/kong/groupservice/service/PostService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/PostService.java
@@ -10,10 +10,13 @@ import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.domain.entity.profile.Profile;
-import me.kong.groupservice.domain.repository.GroupRepository;
 import me.kong.groupservice.domain.repository.PostRepository;
 import me.kong.groupservice.dto.request.SavePostRequestDto;
 import me.kong.groupservice.mapper.PostMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,5 +62,12 @@ public class PostService {
     public void deletePost(Long id, @UserId Long userId, @GroupId Long groupId) {
         Post post = findPost(id);
         post.setState(State.DELETED);
+    }
+
+    @Transactional
+    public Page<Post> getRecentPosts(Long groupId, State state, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
+
+        return postRepository.findRecentPost(groupId, state, pageable);
     }
 }

--- a/group-service/src/test/java/me/kong/groupservice/service/PostServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/PostServiceTest.java
@@ -1,6 +1,7 @@
 package me.kong.groupservice.service;
 
 import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.domain.entity.post.PostScope;
 import me.kong.groupservice.domain.entity.profile.Profile;
@@ -35,8 +36,11 @@ class PostServiceTest {
     @Mock
     ProfileService profileService;
 
+    @Mock
+    GroupService groupService;
 
     SavePostRequestDto savePostRequestDto;
+    Group group;
     Profile profile;
     Post post;
 
@@ -44,9 +48,12 @@ class PostServiceTest {
     Long groupId = 2L;
     Long postId = 3L;
     Long userId = 4L;
+
     String title = "테스트 제목";
     String content = "테스트 내용";
+
     PostScope scope = PostScope.GROUP_ONLY;
+
 
 
     @Test
@@ -59,7 +66,7 @@ class PostServiceTest {
 
         //then
         verify(profileService, times(1)).getLoggedInProfile(userId, groupId);
-        verify(postMapper, times(1)).toEntity(savePostRequestDto, groupId, profileId);
+        verify(postMapper, times(1)).toEntity(savePostRequestDto, group, profile);
         verify(postRepository, times(1)).save(post);
     }
 
@@ -110,12 +117,15 @@ class PostServiceTest {
 
 
     private void savePostSetting(PostScope scope, State state) {
+        group = mock();
         profile = mock();
-        when(profile.getId()).thenReturn(profileId);
+
         savePostRequestDto = makeSavePostRequestDto(scope);
         post = makePost(state);
+
+        when(groupService.findGroupById(any())).thenReturn(group);
         when(profileService.getLoggedInProfile(userId, groupId)).thenReturn(profile);
-        when(postMapper.toEntity(savePostRequestDto, groupId, profile.getId())).thenReturn(post);
+        when(postMapper.toEntity(savePostRequestDto, group, profile)).thenReturn(post);
     }
 
     private SavePostRequestDto makeSavePostRequestDto(PostScope scope) {
@@ -132,8 +142,8 @@ class PostServiceTest {
                 .content(content)
                 .postScope(scope)
                 .state(state)
-                .groupId(groupId)
-                .profileId(profileId)
+                .group(group)
+                .profile(profile)
                 .build();
     }
 }


### PR DESCRIPTION
## 개발 내용
- 오프셋 기반 페이징 적용
- N+1 문제 해결을 위한 `fetch join` 사용

## 개발 코멘트
- 현재 단일 그룹에 대한 게시글 조회만 지원하지만, `OPEN` 상태의 게시글의 경우 모든 그룹의 게시글이 조회되어야 합니다.
- 게시글 상태에 따라 제한이 추가될 수 있습니다.
- 이에 QueryDSL을 도입하여 보다 쉽게 동적쿼리를 지원할 예정입니다.