### PR TITLE
[#48] QueryDSL 도입

### DIFF
--- a/common-library/build.gradle
+++ b/common-library/build.gradle
@@ -45,6 +45,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//Querydsl 추가
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/group-service/build.gradle
+++ b/group-service/build.gradle
@@ -30,6 +30,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    //Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
     compileOnly 'org.projectlombok:lombok'
@@ -55,4 +61,8 @@ dependencyManagement {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+clean {
+    delete file('src/main/generated')
 }

--- a/group-service/src/main/java/me/kong/groupservice/common/config/QuerydslConfig.java
+++ b/group-service/src/main/java/me/kong/groupservice/common/config/QuerydslConfig.java
@@ -1,0 +1,16 @@
+package me.kong.groupservice.common.config;
+
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/PostRepository.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/PostRepository.java
@@ -1,21 +1,11 @@
 package me.kong.groupservice.domain.repository;
 
-import me.kong.groupservice.domain.entity.State;
 import me.kong.groupservice.domain.entity.post.Post;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import me.kong.groupservice.domain.repository.query.CustomPostRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
-
-    @Query("select p from Post p " +
-            " join fetch p.group g" +
-            " join fetch p.profile pf" +
-            " where p.state = :state and g.id = :groupId")
-    Page<Post> findRecentPost(@Param("groupId") Long groupId, @Param("state") State state, Pageable pageable);
+public interface PostRepository extends JpaRepository<Post, Long>, CustomPostRepository {
 }

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/query/CustomPostRepository.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/query/CustomPostRepository.java
@@ -1,0 +1,12 @@
+package me.kong.groupservice.domain.repository.query;
+
+import me.kong.groupservice.domain.entity.post.Post;
+import me.kong.groupservice.dto.request.condition.PostSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+
+public interface CustomPostRepository {
+
+    Page<Post> searchRecentPosts(PostSearchCondition cond, Pageable pageable);
+}

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/query/PostRepositoryImpl.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/query/PostRepositoryImpl.java
@@ -1,0 +1,62 @@
+package me.kong.groupservice.domain.repository.query;
+
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import me.kong.groupservice.domain.entity.post.Post;
+import me.kong.groupservice.domain.entity.post.PostScope;
+import me.kong.groupservice.dto.request.condition.PostSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static me.kong.groupservice.domain.entity.group.QGroup.*;
+import static me.kong.groupservice.domain.entity.post.QPost.*;
+import static me.kong.groupservice.domain.entity.profile.QProfile.*;
+
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements CustomPostRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Post> searchRecentPosts(PostSearchCondition cond, Pageable pageable) {
+        List<Post> content = queryFactory
+                .select(post)
+                .from(post)
+                .join(post.group, group).fetchJoin()
+                .join(post.profile, profile).fetchJoin()
+                .where(
+                        groupIdEq(cond.getGroupId()),
+                        postScopeEq(cond.getPostScope()),
+                        post.state.eq(cond.getState())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalCount = queryFactory
+                .select(post.count())
+                .from(post)
+                .where(
+                        groupIdEq(cond.getGroupId()),
+                        postScopeEq(cond.getPostScope()),
+                        post.state.eq(cond.getState())
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, totalCount);
+    }
+
+    private BooleanExpression postScopeEq(PostScope postScope) {
+        return postScope != null ? post.postScope.eq(postScope) : null;
+    }
+
+    private BooleanExpression groupIdEq(Long groupId) {
+        return groupId != null ? post.group.id.eq(groupId) : null;
+    }
+}

--- a/group-service/src/main/java/me/kong/groupservice/dto/request/condition/PostSearchCondition.java
+++ b/group-service/src/main/java/me/kong/groupservice/dto/request/condition/PostSearchCondition.java
@@ -1,0 +1,15 @@
+package me.kong.groupservice.dto.request.condition;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import me.kong.groupservice.domain.entity.State;
+import me.kong.groupservice.domain.entity.post.PostScope;
+
+@Getter
+@Builder
+public class PostSearchCondition {
+    Long groupId;
+    PostScope postScope;
+    State state;
+}

--- a/group-service/src/main/java/me/kong/groupservice/service/PostService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/PostService.java
@@ -12,6 +12,7 @@ import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.domain.repository.PostRepository;
 import me.kong.groupservice.dto.request.SavePostRequestDto;
+import me.kong.groupservice.dto.request.condition.PostSearchCondition;
 import me.kong.groupservice.mapper.PostMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -65,9 +66,9 @@ public class PostService {
     }
 
     @Transactional
-    public Page<Post> getRecentPosts(Long groupId, State state, int page, int size) {
+    public Page<Post> getRecentPosts(PostSearchCondition cond, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
 
-        return postRepository.findRecentPost(groupId, state, pageable);
+        return postRepository.searchRecentPosts(cond, pageable);
     }
 }


### PR DESCRIPTION
## 개발 내용
### 기존 문제사항
> - 현재 단일 그룹에 대한 게시글 조회만 지원하지만, PUBLIC 상태의 게시글의 경우 모든 그룹의 게시글이 조회되어야 합니다.
> - 게시글 상태에 따라 제한이 추가될 수 있습니다.

### 변경 사항
- 보다 쉽게 동적쿼리를 작성할 수 있도록 `QueryDSL` 을 도입하였습니다.
- `PUBLIC` 게시글을 모두 조회하는 API가 추가되었습니다.

## 개발 코멘트
- 발생하는 쿼리에 따라 접근제어가 필요합니다. 서비스 로직에서 진행할 예정입니다.