### PR TITLE
[#48] 커서 기반 페이징 적용

### DIFF
--- a/group-service/src/main/java/me/kong/groupservice/controller/PostController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/PostController.java
@@ -15,7 +15,7 @@ import me.kong.groupservice.dto.response.PostResponseDto;
 import me.kong.groupservice.mapper.PostMapper;
 import me.kong.groupservice.service.PostService;
 import me.kong.groupservice.service.ProfileService;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -36,8 +36,8 @@ public class PostController {
 
 
     @GetMapping("/posts")
-    public ResponseEntity<Page<PostListResponseDto>> getPostList(
-            @RequestParam(required = false , defaultValue = "0") int page,
+    public ResponseEntity<Slice<PostListResponseDto>> getPostList(
+            @RequestParam(required = false) Long cursorId,
             @RequestParam(required = false, defaultValue = "10") int size) {
 
         PostSearchCondition cond = PostSearchCondition.builder()
@@ -45,16 +45,16 @@ public class PostController {
                 .state(State.GENERAL)
                 .build();
 
-        Page<Post> posts = postService.getRecentPosts(cond, page, size);
+        Slice<Post> posts = postService.getRecentPublicPosts(cursorId, cond, size);
 
         return new ResponseEntity<>(postMapper.toDto(posts), HttpStatus.OK);
     }
 
     @GetMapping("/{groupId}/posts")
-    public ResponseEntity<Page<PostListResponseDto>> getPostList(
+    public ResponseEntity<Slice<PostListResponseDto>> getPostSlice(
             @PathVariable Long groupId,
+            @RequestParam(required = false) Long cursorId,
             @RequestParam(required = false, defaultValue = "GENERAL") State state,
-            @RequestParam(required = false , defaultValue = "0") int page,
             @RequestParam(required = false, defaultValue = "10") int size) {
 
         PostSearchCondition cond = PostSearchCondition.builder()
@@ -62,7 +62,7 @@ public class PostController {
                 .state(state)
                 .build();
 
-        Page<Post> posts = postService.getRecentPosts(cond, page, size);
+        Slice<Post> posts = postService.getRecentGroupPosts(cursorId, cond, size);
 
         return new ResponseEntity<>(postMapper.toDto(posts), HttpStatus.OK);
     }

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/query/CustomPostRepository.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/query/CustomPostRepository.java
@@ -2,11 +2,11 @@ package me.kong.groupservice.domain.repository.query;
 
 import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.dto.request.condition.PostSearchCondition;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 
 public interface CustomPostRepository {
 
-    Page<Post> searchRecentPosts(PostSearchCondition cond, Pageable pageable);
+    Slice<Post> searchRecentPosts(Long cursorId, PostSearchCondition cond, Pageable pageable);
 }

--- a/group-service/src/main/java/me/kong/groupservice/mapper/PostMapper.java
+++ b/group-service/src/main/java/me/kong/groupservice/mapper/PostMapper.java
@@ -7,7 +7,7 @@ import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.dto.request.SavePostRequestDto;
 import me.kong.groupservice.dto.response.PostListResponseDto;
 import me.kong.groupservice.dto.response.PostResponseDto;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 
@@ -37,7 +37,7 @@ public class PostMapper {
                 .build();
     }
 
-    public Page<PostListResponseDto> toDto(Page<Post> posts) {
+    public Slice<PostListResponseDto> toDto(Slice<Post> posts) {
         return posts.map(p -> PostListResponseDto.builder()
                 .id(p.getId())
                 .title(p.getTitle())

--- a/group-service/src/main/java/me/kong/groupservice/service/PostService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/PostService.java
@@ -14,10 +14,7 @@ import me.kong.groupservice.domain.repository.PostRepository;
 import me.kong.groupservice.dto.request.SavePostRequestDto;
 import me.kong.groupservice.dto.request.condition.PostSearchCondition;
 import me.kong.groupservice.mapper.PostMapper;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,10 +62,18 @@ public class PostService {
         post.setState(State.DELETED);
     }
 
-    @Transactional
-    public Page<Post> getRecentPosts(PostSearchCondition cond, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
+    @GroupOnly(role = MEMBER)
+    @Transactional(readOnly = true)
+    public Slice<Post> getRecentGroupPosts(Long cursorId, PostSearchCondition cond, int size) {
+        Pageable pageable = PageRequest.of(0, size);
 
-        return postRepository.searchRecentPosts(cond, pageable);
+        return postRepository.searchRecentPosts(cursorId, cond, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<Post> getRecentPublicPosts(Long cursorId, PostSearchCondition cond, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        return postRepository.searchRecentPosts(cursorId, cond, pageable);
     }
 }


### PR DESCRIPTION
## 구현 내용
- 기존 오프셋 기반의 페이징을 커서 기반 페이징으로 변경하였습니다.
- 그룹 게시글 조회 기능에 인가를 추가하였습니다.

## 개발 코멘트
- 커서 기반 페이징을 적용한 후 API 성능 테스트를 진행하였습니다.
- 어플리케이션 특성 상, 최신 게시글이 자주 조회되기에 현재 상황에서 성능 상 이점은 없다고 생각했습니다.
- 다만, 오프셋 기반의 페이징의 경우 중복된 게시글이 노출될 가능성이 상당하며, 이는 UX에 큰 영향을 미칠 것이라 판단, 커서 기반 페이징을 적용하였습니다.