### PR TITLE
[#60] API 경로 및 라우팅 정보 수정

### DIFF
--- a/api-gateway/src/main/resources/application-route.yml
+++ b/api-gateway/src/main/resources/application-route.yml
@@ -9,8 +9,8 @@ spring:
         - id: user-service
           uri: lb://user-service
           predicates:
-            - Path=/api/users/**
+            - Path=/user-service/**
         - id: group-service
           uri: lb://group-service
           predicates:
-            - Path=/api/groups/**
+            - Path=/group-service/**

--- a/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/GroupController.java
@@ -29,7 +29,7 @@ import static me.kong.commonlibrary.constant.HttpStatusResponseEntity.RESPONSE_O
 
 @Slf4j
 @RestController
-@RequestMapping("/api/groups")
+@RequestMapping("/group-service/api/groups")
 @RequiredArgsConstructor
 public class GroupController {
 

--- a/group-service/src/main/java/me/kong/groupservice/controller/PostController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/PostController.java
@@ -25,7 +25,7 @@ import static me.kong.commonlibrary.constant.HttpStatusResponseEntity.RESPONSE_O
 
 @Slf4j
 @RestController
-@RequestMapping("/api/groups")
+@RequestMapping("/group-service/api/groups")
 @RequiredArgsConstructor
 public class PostController {
 

--- a/user-service/src/main/java/me/kong/userservice/controller/UserController.java
+++ b/user-service/src/main/java/me/kong/userservice/controller/UserController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import static me.kong.commonlibrary.constant.HttpStatusResponseEntity.RESPONSE_OK;
 
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/user-service/api/users")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;


### PR DESCRIPTION
## 개발 내용
- `user-service` 및 `group-service` 의 API 앞에 마이크로서비스 구분자 추가
- API 경로 변경에 따른 `api-gateway` 라우팅 정보 수정

## 개발 코멘트
- 마이크로서비스 구분자가 없을 경우 API가 개발됨에 따라 `api-gateway` 의 라우팅 정보가 수정되어야 합니다
- 이에 각 API 경로에 구분자를 추가하였습니다.