### PR TITLE
모니터링을 위한 의존성 추가

### DIFF
--- a/common-library/src/main/java/me/kong/commonlibrary/event/dto/GroupMemberIncreaseRequestDto.java
+++ b/common-library/src/main/java/me/kong/commonlibrary/event/dto/GroupMemberIncreaseRequestDto.java
@@ -2,6 +2,7 @@ package me.kong.commonlibrary.event.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import me.kong.commonlibrary.event.BaseEvent;
 
 import java.math.BigDecimal;
@@ -10,6 +11,7 @@ import static me.kong.commonlibrary.util.AmountCalculator.getGroupIncreaseAmount
 
 
 @Getter
+@NoArgsConstructor
 public class GroupMemberIncreaseRequestDto {
     private Long groupId;
     private Long userId;

--- a/group-service/build.gradle
+++ b/group-service/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'me.kong:common-library:0.0.3-SNAPSHOT'
+
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.11.0'
 }
 
 dependencyManagement {

--- a/group-service/src/main/resources/application-util.yml
+++ b/group-service/src/main/resources/application-util.yml
@@ -1,0 +1,8 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.5'
 }
 
+ext {
+    springCloudVersion = "2023.0.3"
+}
+
 group = 'me.kong'
 version = '0.0.1-SNAPSHOT'
 
@@ -24,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     implementation 'org.projectlombok:lombok'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     annotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -33,9 +39,16 @@ dependencies {
     testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'me.kong:common-library:0.0.3-SNAPSHOT'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+    }
 }
 
 tasks.named('test') {

--- a/payment-service/src/main/resources/application-util.yml
+++ b/payment-service/src/main/resources/application-util.yml
@@ -1,0 +1,8 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"
+  metrics:
+    tags:
+      application: ${spring.application.name}


### PR DESCRIPTION
## 개발 사항
- `prometheus`, `grafana` 적용을 위해 의존성을 추가했습니다.
- kafka 통신 시 사용되는 DTO의 디폴트 생성자를 추가했습니다.