### PR TITLE
[#65] Resilience4j - Circuit breaker 패턴 적용

### DIFF
--- a/group-service/build.gradle
+++ b/group-service/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/group-service/src/main/java/me/kong/groupservice/client/circuitbreaker/UserServiceCircuitBreaker.java
+++ b/group-service/src/main/java/me/kong/groupservice/client/circuitbreaker/UserServiceCircuitBreaker.java
@@ -1,0 +1,27 @@
+package me.kong.groupservice.client.circuitbreaker;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.RequiredArgsConstructor;
+import me.kong.commonlibrary.event.dto.UserListRequestDto;
+import me.kong.commonlibrary.event.dto.UserListResponseDto;
+import me.kong.groupservice.client.UserServiceClient;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserServiceCircuitBreaker {
+
+    private final UserServiceClient userServiceClient;
+
+    @CircuitBreaker(name = "USER_SERVICE_CIRCUIT_BREAKER", fallbackMethod = "getUserInfoFallback")
+    public List<UserListResponseDto> getUserInfo(UserListRequestDto dto) {
+        return userServiceClient.getUserInfo(dto);
+    }
+
+    public List<UserListResponseDto> getUserInfoFallback(UserListRequestDto requestDto, Throwable throwable) {
+        return new ArrayList<>();
+    }
+}

--- a/group-service/src/test/java/me/kong/groupservice/service/GroupJoinRequestServiceTest.java
+++ b/group-service/src/test/java/me/kong/groupservice/service/GroupJoinRequestServiceTest.java
@@ -2,6 +2,7 @@ package me.kong.groupservice.service;
 
 import me.kong.commonlibrary.util.JwtReader;
 import me.kong.groupservice.client.UserServiceClient;
+import me.kong.groupservice.client.circuitbreaker.UserServiceCircuitBreaker;
 import me.kong.groupservice.domain.entity.GroupJoinRequest.GroupJoinRequest;
 import me.kong.groupservice.domain.entity.group.Group;
 import me.kong.groupservice.domain.repository.GroupJoinRequestRepository;
@@ -38,7 +39,7 @@ class GroupJoinRequestServiceTest {
     GroupJoinRequestMapper groupJoinRequestMapper;
 
     @Mock
-    UserServiceClient userServiceClient;
+    UserServiceCircuitBreaker userServiceClient;
 
 
     GroupJoinRequest request;


### PR DESCRIPTION
## 개발 사항
- `circuit breaker` 패턴을 적용해 장애 전파를 방지했습니다.
- `user-service` 가 응답하지 못할 시 `group-service` 에 저장되어 있는 닉네임을 대신 반환합니다.