### PR TITLE
[#75] 게시글 목록 조회 성능 개선

### DIFF
--- a/group-service/src/main/java/me/kong/groupservice/controller/PostController.java
+++ b/group-service/src/main/java/me/kong/groupservice/controller/PostController.java
@@ -45,9 +45,9 @@ public class PostController {
                 .state(State.GENERAL)
                 .build();
 
-        Slice<Post> posts = postService.getRecentPublicPosts(cursorId, cond, size);
+        Slice<PostListResponseDto> postLists = postService.getRecentPublicPosts(cursorId, cond, size);
 
-        return new ResponseEntity<>(postMapper.toDto(posts), HttpStatus.OK);
+        return new ResponseEntity<>(postLists, HttpStatus.OK);
     }
 
     @GetMapping("/{groupId}/posts")
@@ -62,9 +62,9 @@ public class PostController {
                 .state(state)
                 .build();
 
-        Slice<Post> posts = postService.getRecentGroupPosts(cursorId, cond, size, jwtReader.getUserId(), groupId);
+        Slice<PostListResponseDto> postLists = postService.getRecentGroupPosts(cursorId, cond, size, jwtReader.getUserId(), groupId);
 
-        return new ResponseEntity<>(postMapper.toDto(posts), HttpStatus.OK);
+        return new ResponseEntity<>(postLists, HttpStatus.OK);
     }
 
     @PostMapping("/{groupId}/posts")

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/query/CustomPostRepository.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/query/CustomPostRepository.java
@@ -1,12 +1,12 @@
 package me.kong.groupservice.domain.repository.query;
 
-import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.dto.request.condition.PostSearchCondition;
+import me.kong.groupservice.dto.response.PostListResponseDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 
 public interface CustomPostRepository {
 
-    Slice<Post> searchRecentPosts(Long cursorId, PostSearchCondition cond, Pageable pageable);
+    Slice<PostListResponseDto> searchRecentPosts(Long cursorId, PostSearchCondition cond, Pageable pageable);
 }

--- a/group-service/src/main/java/me/kong/groupservice/domain/repository/query/PostRepositoryImpl.java
+++ b/group-service/src/main/java/me/kong/groupservice/domain/repository/query/PostRepositoryImpl.java
@@ -2,16 +2,17 @@ package me.kong.groupservice.domain.repository.query;
 
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import me.kong.groupservice.domain.entity.post.Post;
 import me.kong.groupservice.domain.entity.post.PostScope;
 import me.kong.groupservice.dto.request.condition.PostSearchCondition;
+import me.kong.groupservice.dto.response.PostListResponseDto;
+import me.kong.groupservice.dto.response.QPostListResponseDto;
 import org.springframework.data.domain.*;
 
 import java.util.List;
 
-import static me.kong.groupservice.domain.entity.group.QGroup.*;
 import static me.kong.groupservice.domain.entity.post.QPost.*;
 import static me.kong.groupservice.domain.entity.profile.QProfile.*;
 
@@ -22,7 +23,7 @@ public class PostRepositoryImpl implements CustomPostRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<Post> searchRecentPosts(Long postId, PostSearchCondition cond, Pageable pageable) {
+    public Slice<PostListResponseDto> searchRecentPosts(Long postId, PostSearchCondition cond, Pageable pageable) {
         List<Long> postIds = queryFactory
                 .select(post.id)
                 .from(post)
@@ -41,17 +42,19 @@ public class PostRepositoryImpl implements CustomPostRepository {
             hasNext = true;
         }
 
-        List<Post> content = queryFactory
-                .select(post)
+        List<PostListResponseDto> postLists = queryFactory
+                .select(new QPostListResponseDto(
+                        post.id,
+                        Expressions.stringTemplate("SUBSTRING({0}, 1, 300)", post.content),
+                        post.group.id, post.profile.id,
+                        post.profile.nickname, post.updatedDate))
                 .from(post)
-                .join(post.group, group).fetchJoin()
-                .join(post.profile, profile).fetchJoin()
+                .join(post.profile, profile)
                 .where(post.id.in(postIds))
                 .orderBy(post.id.desc())
-                .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        return new SliceImpl<>(content, pageable, hasNext);
+        return new SliceImpl<>(postLists, pageable, hasNext);
     }
 
     private BooleanExpression postIdLt(Long postId) {

--- a/group-service/src/main/java/me/kong/groupservice/dto/response/PostListResponseDto.java
+++ b/group-service/src/main/java/me/kong/groupservice/dto/response/PostListResponseDto.java
@@ -1,13 +1,15 @@
 package me.kong.groupservice.dto.response;
 
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@NoArgsConstructor
 public class PostListResponseDto {
     private Long id;
     private String content;
@@ -15,4 +17,15 @@ public class PostListResponseDto {
     private Long profileId;
     private String nickname;
     private LocalDateTime updatedDate;
+
+    @Builder
+    @QueryProjection
+    public PostListResponseDto(Long id, String content, Long groupId, Long profileId, String nickname, LocalDateTime updatedDate) {
+        this.id = id;
+        this.content = content;
+        this.groupId = groupId;
+        this.profileId = profileId;
+        this.nickname = nickname;
+        this.updatedDate = updatedDate;
+    }
 }

--- a/group-service/src/main/java/me/kong/groupservice/service/PostService.java
+++ b/group-service/src/main/java/me/kong/groupservice/service/PostService.java
@@ -13,6 +13,7 @@ import me.kong.groupservice.domain.entity.profile.Profile;
 import me.kong.groupservice.domain.repository.PostRepository;
 import me.kong.groupservice.dto.request.SavePostRequestDto;
 import me.kong.groupservice.dto.request.condition.PostSearchCondition;
+import me.kong.groupservice.dto.response.PostListResponseDto;
 import me.kong.groupservice.mapper.PostMapper;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
@@ -64,14 +65,14 @@ public class PostService {
 
     @GroupOnly(role = MEMBER)
     @Transactional(readOnly = true)
-    public Slice<Post> getRecentGroupPosts(Long cursorId, PostSearchCondition cond, int size,  @UserId Long userId, @GroupId Long groupId) {
+    public Slice<PostListResponseDto> getRecentGroupPosts(Long cursorId, PostSearchCondition cond, int size, @UserId Long userId, @GroupId Long groupId) {
         Pageable pageable = PageRequest.of(0, size);
 
         return postRepository.searchRecentPosts(cursorId, cond, pageable);
     }
 
     @Transactional(readOnly = true)
-    public Slice<Post> getRecentPublicPosts(Long cursorId, PostSearchCondition cond, int size) {
+    public Slice<PostListResponseDto> getRecentPublicPosts(Long cursorId, PostSearchCondition cond, int size) {
         Pageable pageable = PageRequest.of(0, size);
 
         return postRepository.searchRecentPosts(cursorId, cond, pageable);


### PR DESCRIPTION
## 개발 사항
### 1. JPA 사용 시 발생하는 페이징 문제 해결
- `페이징 쿼리` 와 `조회 쿼리` 를 구분하였습니다.
- 4분 51초 → 0.1초로 응답 시간 개선
#### 기존
![image](https://github.com/user-attachments/assets/1945bd5d-59b5-48cd-a0cf-ba23f993a044)
#### 개선
![image](https://github.com/user-attachments/assets/d8ccd417-c8b8-46e5-9fc6-141a20b09043)

### 2. 너무 긴 게시글 내용 일부만 반환하도록 변경
- 게시글이 너무 긴 경우 데이터 크기 상승
- 300자 제한을 두어 `목록 조회`시엔 일부만 반환받도록 수정
- 168kb → 4.39kb로 감소

#### 기존
![image](https://github.com/user-attachments/assets/9b7da571-e3f4-44fc-a746-f29662d70079)

#### 개선
![image](https://github.com/user-attachments/assets/277af1b7-522a-4b0b-9583-f8afe1b2a389)